### PR TITLE
Add contributing docs, slide gen docs, and branch protection status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,15 +46,21 @@ examples/           Example and reference files
 
 src/                Source code
   sdoc.js             Parser and HTML renderer (~2000 lines)
+  slide-renderer.js   SDOC-to-HTML slide deck renderer
   extension.js        VS Code extension with preview and document server
   site-template/      Shared viewer templates (index.html, viewer.css)
+
+themes/             Slide themes
+  default/            Built-in default theme (CSS + navigation JS)
 
 test/               Test files
   test-all.js         Comprehensive test suite (node test/test-all.js)
   test-knr.js         K&R brace placement tests (node test/test-knr.js)
+  test-slides.js      Slide renderer tests (node test/test-slides.js)
   *.sdoc              Test fixture files
 
 tools/              CLI tools
+  build-slides.js     Build HTML slides from SDOC (node tools/build-slides.js)
   serve_docs.py       CLI to start a local SDOC document server
   generate_guide.js   Generates SDOC_GUIDE.md from parser source
   generate_index.js   Generates INDEX.sdoc for a lexica/ directory
@@ -89,7 +95,7 @@ should be evaluated against.
 
 **Testing:**
 - No test framework — tests are plain Node scripts with assert helpers
-- Run all tests: `node test/test-all.js && node test/test-knr.js`
+- Run all tests: `node test/test-all.js && node test/test-knr.js && node test/test-slides.js`
 - Tests exit non-zero on failure
 - Run tests and verify 0 failures before committing parser changes
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,30 @@ python3 tools/serve_docs.py docs/
 
 Or use the **SDOC: Browse Documents** command from the VS Code Command Palette. The viewer opens in your browser with a sidebar, search, and split-pane comparison. Edits are reflected on refresh.
 
+## Building Slides
+
+Generate an HTML slide deck from an SDOC file:
+
+```
+node tools/build-slides.js deck.sdoc [-o output.html] [--theme path/to/theme]
+```
+
+Each top-level scope becomes a slide. Set `type: slides` in `@meta`. See `lexica-common/skills/skill-slides.sdoc` for the full authoring guide.
+
+## Contributing
+
+**Branch strategy:** trunk-based development with branch protection on `main`.
+
+1. Create a short-lived branch off `main` (`fix/parser-bug`, `feat/list-items`, etc.)
+2. Make your changes, commit, push
+3. Open a PR to `main`
+4. Get one approval from another contributor
+5. Merge (squash or regular — your call)
+
+No direct pushes to `main`. Keep branches short — merge often rather than accumulating large changes.
+
+**Auto-sync:** changes to `src/sdoc.js` and `lexica/sdoc-authoring.sdoc` automatically open a PR in the `lexica-common` repo via GitHub Actions. You don't need to do anything — just be aware that parser and skill file changes propagate.
+
 ## Learning the Format
 
 - `docs/guide/intro.sdoc` — what SDOC is and why

--- a/lexica/branch-protection-setup.sdoc
+++ b/lexica/branch-protection-setup.sdoc
@@ -1,0 +1,54 @@
+# Branch Protection Setup @branch-protection-setup
+{
+    # Meta @meta
+    {
+        type: doc
+    }
+
+    # About @about
+    {
+        Status document for setting up branch protection on the sdoc and
+        lexica-common repos. Written because the Bash tool was broken in
+        the Claude Code session and we need to pick this up fresh.
+    }
+
+    # What We Want @goal
+    {
+        Both repos should have branch protection on \`main\`:
+
+        {[.]
+            - No direct pushes to \`main\`
+            - All changes via pull request
+            - 1 approval required before merging
+            - Stale approvals dismissed when new commits are pushed
+        }
+
+        Anyone with write access can approve PRs. No CODEOWNERS for now.
+    }
+
+    # Repos @repos
+    {
+        {[table]
+            Repo | Owner | Plan
+            \`entropicwarrior/sdoc\` | Personal (entropicwarrior) | GitHub Pro
+            \`irreversible-tech/lexica-common\` | Org (irreversible-tech) | Unknown — check
+        }
+    }
+
+    # Resolution @resolution
+    {
+        Completed 2026-02-21. Both repos now have branch rulesets on
+        \`main\` configured via the GitHub UI (Settings > Rules > Rulesets):
+
+        {[.]
+            - \`entropicwarrior/sdoc\` — ruleset "Protect main" active
+            - \`irreversible-tech/lexica-common\` — ruleset "Protect main" active
+            - Both require 1 PR approval, dismiss stale reviews on push
+        }
+
+        The \`gh\` CLI approach failed (fine-grained PAT lacked
+        administration permission on the repos, and the rulesets API
+        requires Team/Enterprise plan via API). Used the GitHub UI
+        instead.
+    }
+}


### PR DESCRIPTION
## Summary
- **README**: Add Building Slides section and Contributing section documenting trunk-based branching strategy and PR requirements
- **AGENTS.md**: Document slide renderer, themes, build tool, and tests
- **lexica/branch-protection-setup.sdoc**: Mark complete — both repos now have branch rulesets via GitHub UI

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Verify AGENTS.md paths are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)