### PR TITLE
Fix PDF page size: use 16:9 landscape for slides

### DIFF
--- a/src/slide-pdf.js
+++ b/src/slide-pdf.js
@@ -64,11 +64,14 @@ function exportPdf(htmlPath, pdfPath) {
     const fileUrl = "file://" + path.resolve(htmlPath);
     const resolvedPdf = path.resolve(pdfPath);
 
+    // 13.333 x 7.5 inches = 16:9 landscape (standard presentation aspect ratio)
     const args = [
       "--headless",
       "--disable-gpu",
       "--no-pdf-header-footer",
       "--print-to-pdf=" + resolvedPdf,
+      "--print-to-pdf-paper-width=13.333",
+      "--print-to-pdf-paper-height=7.5",
       fileUrl,
     ];
 

--- a/themes/default/theme.css
+++ b/themes/default/theme.css
@@ -172,6 +172,11 @@ img {
 /* --- Print / PDF export --- */
 
 @media print {
+  @page {
+    size: 13.333in 7.5in;
+    margin: 0;
+  }
+
   body {
     overflow: visible;
     height: auto;
@@ -181,7 +186,9 @@ img {
     display: flex !important;
     page-break-after: always;
     break-after: page;
+    width: 100vw;
     height: 100vh;
+    max-width: none;
     page-break-inside: avoid;
     break-inside: avoid;
   }


### PR DESCRIPTION
## Summary
- Set Chrome `--print-to-pdf-paper-width/height` to 13.333x7.5 inches (16:9 landscape)
- Add `@page` size rule and remove `max-width` constraint in print CSS
- Slides now fill the full page in standard presentation aspect ratio

Previously the PDF exported as Letter portrait (8.5x11"), which is wrong for slides.

## Test plan
- [x] All tests pass (29/29)
- [x] PDF output confirmed at 960x540 points (16:9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)