### PR TITLE
Vendor slide tools into lexica-common via sync workflow

### DIFF
--- a/.github/workflows/sync-to-lexica-common.yml
+++ b/.github/workflows/sync-to-lexica-common.yml
@@ -5,8 +5,12 @@ on:
     branches: [main]
     paths:
       - 'src/sdoc.js'
+      - 'src/slide-renderer.js'
+      - 'src/slide-pdf.js'
       - 'lexica/sdoc-authoring.sdoc'
       - 'lexica/slide-authoring.sdoc'
+      - 'themes/default/**'
+      - 'tools/build-slides.js'
 
   # Allow manual trigger
   workflow_dispatch:
@@ -27,56 +31,59 @@ jobs:
           token: ${{ secrets.LEXICA_COMMON_PAT }}
           path: lexica-common
 
-      - name: Check for changes
-        id: check
+      - name: Sync files and check for changes
+        id: sync
         run: |
-          PARSER_CHANGED=false
-          SKILL_CHANGED=false
-          SLIDES_CHANGED=false
+          FILES_SUMMARY=""
 
-          if ! diff -q sdoc/src/sdoc.js lexica-common/server/vendor/sdoc-parser.cjs > /dev/null 2>&1; then
-            PARSER_CHANGED=true
-          fi
+          # Parser
+          cp sdoc/src/sdoc.js lexica-common/server/vendor/sdoc-parser.cjs
 
-          if ! diff -q sdoc/lexica/sdoc-authoring.sdoc lexica-common/skills/skill-sdoc.sdoc > /dev/null 2>&1; then
-            SKILL_CHANGED=true
-          fi
+          # Slide renderer (patch require path for vendored parser)
+          sed 's|require("./sdoc")|require("./sdoc-parser.cjs")|' \
+            sdoc/src/slide-renderer.js > lexica-common/server/vendor/slide-renderer.cjs
 
-          if ! diff -q sdoc/lexica/slide-authoring.sdoc lexica-common/skills/skill-slides.sdoc > /dev/null 2>&1; then
-            SLIDES_CHANGED=true
-          fi
+          # Slide PDF export
+          cp sdoc/src/slide-pdf.js lexica-common/server/vendor/slide-pdf.cjs
 
-          echo "parser_changed=$PARSER_CHANGED" >> "$GITHUB_OUTPUT"
-          echo "skill_changed=$SKILL_CHANGED" >> "$GITHUB_OUTPUT"
-          echo "slides_changed=$SLIDES_CHANGED" >> "$GITHUB_OUTPUT"
+          # Build tool (patch require paths for vendored layout)
+          sed \
+            -e 's|require("../src/sdoc")|require("../server/vendor/sdoc-parser.cjs")|' \
+            -e 's|require("../src/slide-renderer")|require("../server/vendor/slide-renderer.cjs")|' \
+            -e 's|require("../src/slide-pdf")|require("../server/vendor/slide-pdf.cjs")|' \
+            -e 's|"themes", "default"|"slides", "themes", "default"|' \
+            sdoc/tools/build-slides.js > lexica-common/tools/build-slides.cjs
 
-          if [ "$PARSER_CHANGED" = true ] || [ "$SKILL_CHANGED" = true ] || [ "$SLIDES_CHANGED" = true ]; then
-            echo "any_changed=true" >> "$GITHUB_OUTPUT"
-          else
+          # Default theme
+          mkdir -p lexica-common/slides/themes/default
+          cp sdoc/themes/default/theme.css lexica-common/slides/themes/default/theme.css
+          cp sdoc/themes/default/theme.js lexica-common/slides/themes/default/theme.js
+
+          # Skill docs
+          cp sdoc/lexica/sdoc-authoring.sdoc lexica-common/skills/skill-sdoc.sdoc
+          cp sdoc/lexica/slide-authoring.sdoc lexica-common/skills/skill-slides.sdoc
+
+          # Check if anything actually changed
+          cd lexica-common
+          if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
             echo "any_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "any_changed=true" >> "$GITHUB_OUTPUT"
+
+            # Build summary of changed files
+            for f in $(git diff --name-only; git ls-files --others --exclude-standard); do
+              FILES_SUMMARY="$FILES_SUMMARY\n- \`$f\`"
+            done
           fi
 
-      - name: Copy, commit, and open PR
-        if: steps.check.outputs.any_changed == 'true'
+          echo "files_summary=$FILES_SUMMARY" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and open PR
+        if: steps.sync.outputs.any_changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.LEXICA_COMMON_PAT }}
         run: |
           cd lexica-common
-
-          # Copy changed files
-          FILES_SUMMARY=""
-          if [ "${{ steps.check.outputs.parser_changed }}" = "true" ]; then
-            cp ../sdoc/src/sdoc.js server/vendor/sdoc-parser.cjs
-            FILES_SUMMARY="$FILES_SUMMARY\n- \`server/vendor/sdoc-parser.cjs\` — vendored SDOC parser"
-          fi
-          if [ "${{ steps.check.outputs.skill_changed }}" = "true" ]; then
-            cp ../sdoc/lexica/sdoc-authoring.sdoc skills/skill-sdoc.sdoc
-            FILES_SUMMARY="$FILES_SUMMARY\n- \`skills/skill-sdoc.sdoc\` — SDOC authoring guide"
-          fi
-          if [ "${{ steps.check.outputs.slides_changed }}" = "true" ]; then
-            cp ../sdoc/lexica/slide-authoring.sdoc skills/skill-slides.sdoc
-            FILES_SUMMARY="$FILES_SUMMARY\n- \`skills/skill-slides.sdoc\` — Slide authoring guide"
-          fi
 
           # Configure git
           git config user.name "github-actions[bot]"
@@ -97,4 +104,4 @@ jobs:
 
           gh pr create \
             --title "Update SDOC files from sdoc repo" \
-            --body "$(printf "Automated sync from [entropicwarrior/sdoc](https://github.com/entropicwarrior/sdoc).\n\n**Files updated:**\n$FILES_SUMMARY\n\nTriggered by commit ${{ github.sha }}.")"
+            --body "$(printf "Automated sync from [entropicwarrior/sdoc](https://github.com/entropicwarrior/sdoc).\n\n**Files updated:**\n${{ steps.sync.outputs.files_summary }}\n\nTriggered by commit ${{ github.sha }}.")"

--- a/lexica/slide-authoring.sdoc
+++ b/lexica/slide-authoring.sdoc
@@ -47,10 +47,10 @@
 
         # Building Slides @building
         {
-            Use the CLI tool from the sdoc repo:
+            Use the CLI tool from the lexica-common repo:
 
             ```
-            node ~/repos/sdoc/tools/build-slides.js deck.sdoc
+            node ~/repos/lexica-common/tools/build-slides.cjs deck.sdoc
             ```
 
             This produces \`deck.html\` — a self-contained HTML file. Open it
@@ -59,28 +59,29 @@
             To specify output path:
 
             ```
-            node ~/repos/sdoc/tools/build-slides.js deck.sdoc -o output.html
+            node ~/repos/lexica-common/tools/build-slides.cjs deck.sdoc -o output.html
             ```
 
             To export as PDF:
 
             ```
-            node ~/repos/sdoc/tools/build-slides.js deck.sdoc --pdf
+            node ~/repos/lexica-common/tools/build-slides.cjs deck.sdoc --pdf
             ```
 
-            This produces \`deck.pdf\` using headless Chrome. Each slide becomes
-            one page. Requires Chrome or Chromium installed on the system.
+            This produces \`deck.pdf\` using headless Chrome in 16:9 landscape
+            format. Each slide becomes one page. Requires Chrome or Chromium
+            installed on the system.
 
             To use the company theme:
 
             ```
-            node ~/repos/sdoc/tools/build-slides.js deck.sdoc --theme ~/repos/lexica-common/slides/themes/company
+            node ~/repos/lexica-common/tools/build-slides.cjs deck.sdoc --theme ~/repos/lexica-common/slides/themes/company
             ```
 
             Flags can be combined:
 
             ```
-            node ~/repos/sdoc/tools/build-slides.js deck.sdoc --pdf --theme ~/repos/lexica-common/slides/themes/company -o presentation.pdf
+            node ~/repos/lexica-common/tools/build-slides.cjs deck.sdoc --pdf --theme ~/repos/lexica-common/slides/themes/company -o presentation.pdf
             ```
         }
 


### PR DESCRIPTION
## Summary
- Update sync workflow to copy slide renderer, slide-pdf, build-slides tool, and default theme to lexica-common (with require paths patched for .cjs vendored layout)
- Update skill doc to point at `~/repos/lexica-common/tools/build-slides.cjs` so users don't need the sdoc repo locally
- Simplify sync workflow: always copy all files, diff after

This was meant to be part of PR #4 but was pushed after merge.

## Test plan
- [x] `node ~/repos/lexica-common/tools/build-slides.cjs` produces correct 16:9 PDF
- [x] All slide tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)