### PR TITLE
Fix sync workflow: create tools/ directory before writing

### DIFF
--- a/.github/workflows/sync-to-lexica-common.yml
+++ b/.github/workflows/sync-to-lexica-common.yml
@@ -47,6 +47,7 @@ jobs:
           cp sdoc/src/slide-pdf.js lexica-common/server/vendor/slide-pdf.cjs
 
           # Build tool (patch require paths for vendored layout)
+          mkdir -p lexica-common/tools
           sed \
             -e 's|require("../src/sdoc")|require("../server/vendor/sdoc-parser.cjs")|' \
             -e 's|require("../src/slide-renderer")|require("../server/vendor/slide-renderer.cjs")|' \


### PR DESCRIPTION
## Summary
Add `mkdir -p lexica-common/tools` before the `sed` redirect that writes `build-slides.cjs`. The previous sync run failed because `tools/` doesn't exist yet in lexica-common on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)