### PR TITLE
Fix PDF export with non-default themes

### DIFF
--- a/src/slide-renderer.js
+++ b/src/slide-renderer.js
@@ -238,7 +238,23 @@ function renderSlides(nodes, options = {}) {
   const title = meta.properties?.title
     || (nodes.length === 1 && nodes[0].title ? nodes[0].title : "Slides");
 
-  const cssTag = themeCss ? `<style>\n${themeCss}\n</style>` : "";
+  // Structural print/PDF styles — always injected regardless of theme.
+  // Themes provide visual styling; page-break behaviour is not theme-specific.
+  const printCss = `@media print {
+  @page { size: 13.333in 7.5in; margin: 0; }
+  body { overflow: visible; height: auto; }
+  .slide {
+    display: flex !important;
+    page-break-after: always; break-after: page;
+    width: 100vw; height: 100vh; max-width: none;
+    page-break-inside: avoid; break-inside: avoid;
+  }
+  .slide:last-child { page-break-after: auto; break-after: auto; }
+  .controls { display: none; }
+  .notes { display: none; }
+}`;
+
+  const cssTag = `<style>\n${themeCss}\n${printCss}\n</style>`;
   const jsTag = themeJs ? `<script>\n${themeJs}\n</script>` : "";
 
   return `<!DOCTYPE html>

--- a/themes/default/theme.css
+++ b/themes/default/theme.css
@@ -169,40 +169,5 @@ img {
   user-select: none;
 }
 
-/* --- Print / PDF export --- */
-
-@media print {
-  @page {
-    size: 13.333in 7.5in;
-    margin: 0;
-  }
-
-  body {
-    overflow: visible;
-    height: auto;
-  }
-
-  .slide {
-    display: flex !important;
-    page-break-after: always;
-    break-after: page;
-    width: 100vw;
-    height: 100vh;
-    max-width: none;
-    page-break-inside: avoid;
-    break-inside: avoid;
-  }
-
-  .slide:last-child {
-    page-break-after: auto;
-    break-after: auto;
-  }
-
-  .controls {
-    display: none;
-  }
-
-  .notes {
-    display: none;
-  }
-}
+/* Print / PDF styles are injected by the renderer (slide-renderer.js)
+   so they work with every theme, not just this one. */


### PR DESCRIPTION
## Summary
- Move structural `@media print` CSS from `themes/default/theme.css` into the renderer, so PDF export works with every theme (not just default)
- Isolate headless Chrome with `--headless=new` and `--user-data-dir` to prevent conflicts with running browser sessions

## Test plan
- [x] `node tools/build-slides.js deck.sdoc --pdf --theme company` → 17 pages, 16:9
- [x] `node tools/build-slides.js deck.sdoc --pdf` (default theme) → 17 pages, 16:9
- [ ] `node test/test-slides.js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)