### PR TITLE
Add company and confidential meta properties

### DIFF
--- a/lexica/sdoc-authoring.sdoc
+++ b/lexica/sdoc-authoring.sdoc
@@ -211,12 +211,43 @@
             ```
             # Meta @meta
             {
+                type: doc
+
+                company: Irreversible Inc.
+
+                confidential: true
+
                 style: styles/custom.css
+
                 header: My Header
+
                 footer: My Footer
-                author: Jane Smith
             }
             ```
+
+            Supported properties (separate each with a blank line):
+
+            \`type: doc\` or \`type: skill\` or \`type: slides\` — document type.
+
+            \`company: Name\` — company name, shown in the document footer.
+
+            \`confidential: true\` — adds a confidentiality notice banner.
+            Uses the \`company\` name if set. Use \`confidential: Custom Entity\`
+            to override with a specific entity name.
+
+            \`style: path/to/file.css\` — custom stylesheet (replaces default).
+
+            \`style-append: path/to/file.css\` — additional stylesheet (appended).
+
+            \`header: text\` — page header text (or use a \`# Header\` sub-scope
+            for rich content).
+
+            \`footer: text\` — page footer text (or use a \`# Footer\` sub-scope
+            for rich content).
+
+            \`uuid: ...\` — unique identifier.
+
+            \`tags: tag1, tag2\` — comma-separated tags.
         }
 
         # Escaping @escaping

--- a/lexica/slide-authoring.sdoc
+++ b/lexica/slide-authoring.sdoc
@@ -135,6 +135,14 @@
 
             \`title: Presentation Title\` — sets the HTML page title.
 
+            \`company: Name\` — company name, shown in the bottom-left of
+            every slide.
+
+            \`confidential: true\` — adds a confidentiality notice across
+            the bottom of every slide. Uses the \`company\` name if set.
+            Use \`confidential: Custom Entity\` to override with a specific
+            entity name.
+
             \`theme: company\` — names the intended theme (informational;
             the actual theme is selected via the \`--theme\` CLI flag).
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sdoc",
   "displayName": "SDOC",
   "description": "Preview SDOC files.",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "publisher": "local",
   "engines": {
     "vscode": "^1.95.0"

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -1382,5 +1382,39 @@ test("extractMeta finds @meta inside document scope", () => {
 });
 
 // ============================================================
+console.log("\n--- Company and confidential ---");
+
+test("extractMeta promotes company and confidential", () => {
+  const r = parseSdoc("# Meta @meta\n{\n    company: Acme Corp\n\n    confidential: true\n}\n# Body\n{\n    text\n}");
+  const result = extractMeta(r.nodes);
+  assert(result.meta.company === "Acme Corp", "should promote company");
+  assert(result.meta.confidential === "true", "should promote confidential");
+});
+
+test("confidential: true renders notice in doc HTML", () => {
+  const html = renderHtmlDocument("# Meta @meta\n{\n    confidential: true\n}\n# Body\n{\n    Content.\n}", "Test");
+  assert(html.includes("sdoc-confidential-notice"), "should have notice element");
+  assert(html.includes("CONFIDENTIAL"), "should contain CONFIDENTIAL text");
+});
+
+test("confidential with company renders entity in doc HTML", () => {
+  const html = renderHtmlDocument("# Meta @meta\n{\n    company: Acme Corp\n\n    confidential: true\n}\n# Body\n{\n    Content.\n}", "Test");
+  assert(html.includes("Acme Corp"), "should include company name in notice");
+});
+
+test("company renders in footer of doc HTML", () => {
+  const html = renderHtmlDocument("# Meta @meta\n{\n    company: Acme Corp\n}\n# Body\n{\n    Content.\n}", "Test");
+  assert(html.includes("sdoc-company-footer"), "should have company in footer");
+  assert(html.includes("Acme Corp"), "should have company name");
+  assert(html.includes("sdoc-page-footer"), "should have footer element");
+});
+
+test("no company or confidential produces no notice or company footer", () => {
+  const html = renderHtmlDocument("# Meta @meta\n{\n    type: doc\n}\n# Body\n{\n    Content.\n}", "Test");
+  assert(!html.includes('<div class="sdoc-confidential-notice">'), "no notice element");
+  assert(!html.includes('<span class="sdoc-company-footer">'), "no company footer element");
+});
+
+// ============================================================
 console.log("\n--- Results: " + pass + " passed, " + fail + " failed ---");
 if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Summary
- New `company` and `confidential` meta properties for all SDOC files
- Docs: confidential banner at top, company name in footer
- Slides: both embedded per-slide (works correctly in PDF export)
- Company theme: replaced hardcoded `::after` watermark with meta-driven `.sdoc-company-footer`
- Skill docs updated for both sdoc-authoring and slide-authoring
- Extension bumped to v0.0.33

## Test plan
- [x] `node test/test-all.js` — 175 passed
- [x] `node test/test-slides.js` — 34 passed
- [x] PDF export with company theme — correct page count and 16:9 size
- [ ] VS Code preview with `company` + `confidential` in meta

🤖 Generated with [Claude Code](https://claude.com/claude-code)