### PR TITLE
Preserve scroll position across preview re-renders

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -550,6 +550,26 @@ function buildWebviewScript() {
   }
 
   restoreCollapseState();
+  restoreScrollPosition();
+
+  // Preserve scroll position across re-renders
+  var scrollContainer = document.querySelector('.sdoc-main') || document.documentElement;
+  var scrollTimer = null;
+  scrollContainer.addEventListener('scroll', function() {
+    clearTimeout(scrollTimer);
+    scrollTimer = setTimeout(function() {
+      var state = vscodeApi.getState() || {};
+      state.scrollTop = scrollContainer.scrollTop;
+      vscodeApi.setState(state);
+    }, 100);
+  });
+
+  function restoreScrollPosition() {
+    var state = vscodeApi.getState();
+    if (!state || state.scrollTop == null) return;
+    var container = document.querySelector('.sdoc-main') || document.documentElement;
+    container.scrollTop = state.scrollTop;
+  }
 
   // Inline editing
   document.addEventListener('focusout', function(e) {


### PR DESCRIPTION
## Summary
- Webview saves scroll position via `vscodeApi.setState()` on scroll events (debounced)
- Restores scroll position when HTML is replaced during re-render
- Prevents preview from jumping to the top when editing the source file

## Test plan
- [x] Open a long SDOC file, scroll down, edit source — preview stays in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)