### PR TITLE
Add click navigation, URL hash, and unified slide footer

### DIFF
--- a/.github/workflows/sync-to-lexica-common.yml
+++ b/.github/workflows/sync-to-lexica-common.yml
@@ -52,13 +52,13 @@ jobs:
             -e 's|require("../src/sdoc")|require("../server/vendor/sdoc-parser.cjs")|' \
             -e 's|require("../src/slide-renderer")|require("../server/vendor/slide-renderer.cjs")|' \
             -e 's|require("../src/slide-pdf")|require("../server/vendor/slide-pdf.cjs")|' \
-            -e 's|"themes", "default"|"slides", "themes", "default"|' \
+            -e 's|"themes", "default"|"presentations", "themes", "default"|' \
             sdoc/tools/build-slides.js > lexica-common/tools/build-slides.cjs
 
           # Default theme
-          mkdir -p lexica-common/slides/themes/default
-          cp sdoc/themes/default/theme.css lexica-common/slides/themes/default/theme.css
-          cp sdoc/themes/default/theme.js lexica-common/slides/themes/default/theme.js
+          mkdir -p lexica-common/presentations/themes/default
+          cp sdoc/themes/default/theme.css lexica-common/presentations/themes/default/theme.css
+          cp sdoc/themes/default/theme.js lexica-common/presentations/themes/default/theme.js
 
           # Skill docs
           cp sdoc/lexica/sdoc-authoring.sdoc lexica-common/skills/skill-sdoc.sdoc

--- a/test/test-slides.js
+++ b/test/test-slides.js
@@ -63,7 +63,7 @@ test("multiple slides", () => {
     }
 }
 `);
-  const slideCount = (html.match(/<div class="slide/g) || []).length;
+  const slideCount = (html.match(/<div class="slide">/g) || []).length;
   assert(slideCount === 2, "should have 2 slides, got " + slideCount);
   assert(html.includes("<h2>Slide One</h2>"), "should have first title");
   assert(html.includes("<h2>Slide Two</h2>"), "should have second title");
@@ -110,7 +110,7 @@ test("meta scope is excluded from slides", () => {
     }
 }
 `);
-  const slideCount = (html.match(/<div class="slide/g) || []).length;
+  const slideCount = (html.match(/<div class="slide">/g) || []).length;
   assert(slideCount === 1, "meta should not become a slide, got " + slideCount);
 });
 
@@ -378,7 +378,7 @@ test("produces valid HTML document", () => {
   assert(html.includes("</html>"), "should close html");
 });
 
-test("includes controls div", () => {
+test("includes slide footer with nav indicators", () => {
   const html = parseAndRender(`
 # Deck {
     # Slide {
@@ -386,8 +386,9 @@ test("includes controls div", () => {
     }
 }
 `);
-  assert(html.includes('class="controls"'), "should have controls");
-  assert(html.includes('id="counter"'), "should have counter");
+  assert(html.includes('class="slide-footer"'), "should have slide footer");
+  assert(html.includes('class="nav-prev"'), "should have nav-prev");
+  assert(html.includes('class="nav-next"'), "should have nav-next");
 });
 
 // ============================================================
@@ -554,7 +555,7 @@ test("confidential: true without company renders plain notice", () => {
 }
 `);
   assert(html.includes("sdoc-confidential-notice"), "should have notice");
-  assert(html.includes(">CONFIDENTIAL</"), "should be plain CONFIDENTIAL");
+  assert(html.includes(">CONFIDENTIAL</span>"), "should be plain CONFIDENTIAL");
 });
 
 test("no company or confidential produces no extra elements", () => {
@@ -566,8 +567,8 @@ test("no company or confidential produces no extra elements", () => {
     # Slide { Hello. }
 }
 `);
-  assert(!html.includes('<div class="sdoc-company-footer">'), "no company footer element");
-  assert(!html.includes('<div class="sdoc-confidential-notice">'), "no confidential notice element");
+  assert(!html.includes('<span class="sdoc-company-footer">'), "no company footer element");
+  assert(!html.includes('<span class="sdoc-confidential-notice">'), "no confidential notice element");
 });
 
 // ============================================================

--- a/themes/default/theme.css
+++ b/themes/default/theme.css
@@ -158,16 +158,6 @@ img {
   display: none;
 }
 
-/* --- Slide counter --- */
-
-.controls {
-  position: fixed;
-  bottom: 24px;
-  right: 32px;
-  font-size: 0.85em;
-  color: #aaa;
-  user-select: none;
-}
 
 /* Print / PDF styles are injected by the renderer (slide-renderer.js)
    so they work with every theme, not just this one. */

--- a/themes/default/theme.js
+++ b/themes/default/theme.js
@@ -1,5 +1,5 @@
 // SDOC Slides — Default Theme Runtime
-// Keyboard navigation, touch swipe, slide counter.
+// Keyboard navigation, click navigation, touch swipe, URL hash, nav indicators.
 
 (function () {
   const slides = document.querySelectorAll(".slide");
@@ -9,10 +9,15 @@
     slides[current].classList.remove("active");
     current = Math.max(0, Math.min(n, slides.length - 1));
     slides[current].classList.add("active");
-    const counter = document.getElementById("counter");
-    if (counter) {
-      counter.textContent = (current + 1) + " / " + slides.length;
-    }
+    // Update nav indicators on all slides
+    slides.forEach(function (slide, i) {
+      var prev = slide.querySelector(".nav-prev");
+      var next = slide.querySelector(".nav-next");
+      if (prev) prev.style.visibility = i > 0 ? "visible" : "hidden";
+      if (next) next.style.visibility = i < slides.length - 1 ? "visible" : "hidden";
+    });
+    // Update URL hash without triggering hashchange
+    history.replaceState(null, "", "#" + (current + 1));
   }
 
   document.addEventListener("keydown", function (e) {
@@ -34,6 +39,17 @@
     }
   });
 
+  // Click navigation — right half forward, left half back
+  document.addEventListener("click", function (e) {
+    // Ignore clicks on links, buttons, or interactive elements
+    if (e.target.closest("a, button, input, textarea, select")) return;
+    if (e.clientX > window.innerWidth / 2) {
+      show(current + 1);
+    } else {
+      show(current - 1);
+    }
+  });
+
   // Touch swipe support
   var touchStartX = 0;
   document.addEventListener("touchstart", function (e) {
@@ -45,6 +61,19 @@
     if (dx > 50) show(current - 1);
   });
 
-  // Activate first slide
-  show(0);
+  // Read initial slide from URL hash
+  var startSlide = 0;
+  var hash = window.location.hash;
+  if (hash && hash.match(/^#\d+$/)) {
+    startSlide = parseInt(hash.substring(1), 10) - 1;
+  }
+  show(startSlide);
+
+  // Handle back/forward browser navigation
+  window.addEventListener("hashchange", function () {
+    var h = window.location.hash;
+    if (h && h.match(/^#\d+$/)) {
+      show(parseInt(h.substring(1), 10) - 1);
+    }
+  });
 })();


### PR DESCRIPTION
## Summary
- Click right half of slide to advance, left half to go back
- Slide number in URL hash (`#N`) for deep linking, refresh persistence, and browser back/forward
- Nav indicators (`<` `>`) in unified footer bar, hidden on first/last slide
- Unified footer layout: `< confidential ---gap--- company >` in a single flex container
- Structural CSS injected before theme CSS so themes can override defaults
- Removes old controls div and slide counter
- Updates sync workflow paths from `slides/` to `presentations/` to match lexica-common reorganisation

## Test plan
- [x] All 37 tests pass (`node test/test-slides.js`)
- [ ] Build a slide deck and verify click nav, keyboard nav, and touch swipe
- [ ] Verify URL hash updates on navigation and persists on refresh
- [ ] Verify `<` hidden on first slide, `>` hidden on last slide
- [ ] Verify company footer and confidential notice render correctly in unified footer
- [ ] Verify company theme colour override works (theme CSS after structural CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)