### PR TITLE
Add preview command to explorer context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sdoc",
   "displayName": "SDOC",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "entropicwarrior",
   "license": "MIT",
   "repository": {
@@ -35,7 +35,8 @@
     "onCommand:sdoc.openInBrowser",
     "onCommand:sdoc.browseDocs",
     "onCommand:sdoc.newKnowledgeFile",
-    "onCommand:sdoc.generateAbout"
+    "onCommand:sdoc.generateAbout",
+    "onCommand:sdoc.previewFromExplorer"
   ],
   "scripts": {
     "package": "npx vsce package --out dist/"
@@ -92,6 +93,11 @@
       {
         "command": "sdoc.generateAbout",
         "title": "SDOC: Generate About"
+      },
+      {
+        "command": "sdoc.previewFromExplorer",
+        "title": "Open SDOC Preview",
+        "icon": "$(open-preview)"
       }
     ],
     "configurationDefaults": {
@@ -134,6 +140,11 @@
         }
       ],
       "explorer/context": [
+        {
+          "command": "sdoc.previewFromExplorer",
+          "when": "resourceExtname == .sdoc",
+          "group": "navigation"
+        },
         {
           "command": "sdoc.newKnowledgeFile",
           "group": "navigation"

--- a/src/extension.js
+++ b/src/extension.js
@@ -42,6 +42,12 @@ function activate(context) {
     showPreview(editor.document, vscode.ViewColumn.Beside);
   });
 
+  const previewFromExplorerCommand = vscode.commands.registerCommand("sdoc.previewFromExplorer", async (uri) => {
+    if (!uri) return;
+    const document = await vscode.workspace.openTextDocument(uri);
+    showPreview(document, vscode.ViewColumn.Active);
+  });
+
   const exportHtmlCommand = vscode.commands.registerCommand("sdoc.exportHtml", () => {
     exportHtml();
   });
@@ -292,7 +298,7 @@ function activate(context) {
     await vscode.workspace.applyEdit(editBuilder);
   });
 
-  context.subscriptions.push(previewCommand, previewToSideCommand, exportHtmlCommand, openInBrowserCommand, browseDocsCommand, newKnowledgeFileCommand, generateAboutCommand);
+  context.subscriptions.push(previewCommand, previewToSideCommand, previewFromExplorerCommand, exportHtmlCommand, openInBrowserCommand, browseDocsCommand, newKnowledgeFileCommand, generateAboutCommand);
 
   context.subscriptions.push(
     vscode.languages.registerDocumentSymbolProvider("sdoc", {


### PR DESCRIPTION
## Summary
- Adds "Open SDOC Preview" to the file explorer right-click menu for `.sdoc` files
- Bumps version to 0.1.1

## Test plan
- [ ] Right-click a `.sdoc` file in the explorer → "Open SDOC Preview" appears
- [ ] Clicking it opens the file and shows the preview
- [ ] The option does not appear for non-`.sdoc` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)