### PR TITLE
Fix slides hidden in print mode

### DIFF
--- a/src/slide-renderer.js
+++ b/src/slide-renderer.js
@@ -290,6 +290,9 @@ function renderSlides(nodes, options = {}) {
   body { overflow: visible; height: auto; }
   .slide {
     display: flex !important;
+    position: relative !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
     page-break-after: always; break-after: page;
     width: 100vw; height: 100vh; max-width: none;
     page-break-inside: avoid; break-inside: avoid;


### PR DESCRIPTION
## Summary
- Adds `position: relative`, `opacity: 1`, and `pointer-events: auto` overrides to the print CSS in `slide-renderer.js`
- Ensures slides that are hidden/positioned offscreen during presentation mode render correctly when printing or exporting to PDF

## Test plan
- [ ] Open a slide deck and verify presentation mode still works normally
- [ ] Print/export to PDF and confirm all slides are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)