### PR TITLE
Ship SDOC knowledge files in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,11 @@
 .vscodeignore
 docs/
 examples/
-lexica/
+lexica/INDEX.sdoc
+lexica/requirements.sdoc
+lexica/sdoc-plan.sdoc
+lexica/status.sdoc
+lexica/suggestions.sdoc
 test/
 tools/
 dist/

--- a/knowledge.js
+++ b/knowledge.js
@@ -1,0 +1,2 @@
+const path = require('path');
+module.exports.knowledgeDir = path.join(__dirname, 'lexica');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sdoc",
   "displayName": "SDOC",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "publisher": "entropicwarrior",
   "license": "MIT",
   "repository": {
@@ -25,7 +25,8 @@
     ".": "./index.js",
     "./slides": "./src/slide-renderer.js",
     "./slide-pdf": "./src/slide-pdf.js",
-    "./notion": "./src/notion-renderer.js"
+    "./notion": "./src/notion-renderer.js",
+    "./knowledge": "./knowledge.js"
   },
   "engines": {
     "vscode": "^1.95.0"


### PR DESCRIPTION
## Summary
- Update `.npmignore` to publish three consumer-facing knowledge files (`sdoc-authoring.sdoc`, `slide-authoring.sdoc`, `specification.sdoc`) while continuing to exclude internal files
- Add `knowledge.js` module and `./knowledge` package export so consumers can discover the knowledge directory path
- Bump version to 0.1.5

## Test plan
- [x] `npm pack --dry-run` confirms the three knowledge files are included in the tarball
- [ ] After merge, verify npm publish succeeds via GitHub workflow
- [ ] In lexica-common, install `@entropicwarrior/sdoc@0.1.5` and verify `list_knowledge` shows sdoc-prefixed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)