### PR TITLE
Ship sync-notion tool in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,7 +12,10 @@ lexica/sdoc-plan.sdoc
 lexica/status.sdoc
 lexica/suggestions.sdoc
 test/
-tools/
+tools/build-slides.js
+tools/generate_guide.js
+tools/generate_index.js
+tools/serve_docs.py
 dist/
 vendor/
 themes/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sdoc",
   "displayName": "SDOC",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "publisher": "entropicwarrior",
   "license": "MIT",
   "repository": {
@@ -21,6 +21,9 @@
     "preview",
     "ai-agent"
   ],
+  "bin": {
+    "sdoc-sync-notion": "./tools/sync-notion.js"
+  },
   "exports": {
     ".": "./index.js",
     "./slides": "./src/slide-renderer.js",


### PR DESCRIPTION
## Summary
- Include `tools/sync-notion.js` in the npm package (was previously excluded by `.npmignore`)
- Add `bin` entry so consumers can run `npx sdoc-sync-notion`
- Bump to 0.1.6

## Test plan
- [x] `npm pack --dry-run` confirms `tools/sync-notion.js` is included
- [ ] After publish, `npx @entropicwarrior/sdoc-sync-notion --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)