### PR TITLE
Fix sync-notion crash on files without meta properties

### DIFF
--- a/tools/sync-notion.js
+++ b/tools/sync-notion.js
@@ -96,7 +96,8 @@ function extractNotionPageId(filePath) {
   const text = fs.readFileSync(filePath, "utf-8");
   const parsed = parseSdoc(text);
   const { meta } = extractMeta(parsed.nodes);
-  const pageId = meta.properties["notion-page"] || meta.properties["notion_page"] || null;
+  const props = meta.properties || {};
+  const pageId = props["notion-page"] || props["notion_page"] || null;
   return pageId ? pageId.trim() : null;
 }
 


### PR DESCRIPTION
## Summary
- Guard against `meta.properties` being undefined when `extractMeta` returns an empty meta object
- Fixes crash during directory scan when some `.sdoc` files have no `@meta` scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)