### PR TITLE
Add caution marker, split warning into caution/warning levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Annotate text with semantic meaning that renders as colored highlights:
 |---|---|---|
 | `{+text+}` | Positive | Green |
 | `{=text=}` | Neutral | Blue |
-| `{!text!}` | Warning | Amber |
+| `{^text^}` | Caution | Amber |
+| `{!text!}` | Warning | Orange |
 | `{-text-}` | Negative | Red |
 | `{~text~}` | Highlight | Yellow |
 

--- a/SDOC_GUIDE.md
+++ b/SDOC_GUIDE.md
@@ -222,7 +222,8 @@ Add `borderless` and/or `headerless` flags after `table`:
 | `$$E = mc^2$$` | Display math (centered) |
 | `{+text+}` | Positive marker (green) |
 | `{=text=}` | Neutral marker (blue) |
-| `{!text!}` | Warning marker (amber) |
+| `{^text^}` | Caution marker (amber) |
+| `{!text!}` | Warning marker (orange) |
 | `{-text-}` | Negative marker (red) |
 | `{~text~}` | Highlight (yellow) |
 
@@ -360,7 +361,7 @@ A line of three or more `-`, `*`, or `_`:
 
 ### Escaping
 
-Backslash escapes special characters: `\\` `\{` `\}` `\@` `\[` `\]` `\(` `\)` `\*` `\~` `\#` `\!` `\<` `\>` `\$` `\+` `\=` `\-` `\\``
+Backslash escapes special characters: `\\` `\{` `\}` `\@` `\[` `\]` `\(` `\)` `\*` `\~` `\#` `\!` `\<` `\>` `\$` `\+` `\=` `\-` `\^` `\\``
 
 A line starting with `\#` renders as a literal `#` (not a heading). A line starting with `\>` renders as a literal `>` (not a blockquote). Use `\$` to prevent a dollar sign from starting math mode.
 

--- a/docs/reference/syntax.sdoc
+++ b/docs/reference/syntax.sdoc
@@ -282,7 +282,8 @@ Content of Section B.
             - `$$E = mc^2$$` renders as display math (centered)
             - `{+text+}` renders as {+positive (green) marker+}
             - `{=text=}` renders as {=neutral (blue) marker=}
-            - `{!text!}` renders as {!warning (amber) marker!}
+            - `{^text^}` renders as {^caution (amber) marker^}
+            - `{!text!}` renders as {!warning (orange) marker!}
             - `{-text-}` renders as {-negative (red) marker-}
             - `{~text~}` renders as {~highlighted text~}
         }

--- a/docs/tutorials/first-steps.sdoc
+++ b/docs/tutorials/first-steps.sdoc
@@ -62,7 +62,7 @@ Hello, this is my first SDOC document.
     {
         SDOC supports *emphasis*, **strong**, `code`, ~~strikethrough~~, and math like $E = mc^2$.
 
-        Semantic markers: {+passed+}, {=info=}, {!caution!}, {-failed-}, and {~highlighted~}.
+        Semantic markers: {+passed+}, {=info=}, {^caution^}, {!warning!}, {-failed-}, and {~highlighted~}.
     }
 
     # To Do

--- a/examples/example.sdoc
+++ b/examples/example.sdoc
@@ -24,7 +24,7 @@
         References look like @overview.
 
         You can use *emphasis*, **strong**, and `inline code`.
-        Semantic markers: {+positive+}, {=neutral=}, {!warning!}, {-negative-}. Highlight: {~important note~}. Nesting works: {+**all checks** passed+}.
+        Semantic markers: {+positive+}, {=neutral=}, {^caution^}, {!warning!}, {-negative-}. Highlight: {~important note~}. Nesting works: {+**all checks** passed+}.
         External links look like [SDOC](https://example.com).
     }
     # Examples

--- a/examples/sdoc.template.css
+++ b/examples/sdoc.template.css
@@ -233,7 +233,8 @@ main {
 }
 .sdoc-mark-positive { background-color: rgba(34, 139, 34, 0.15); color: #166016; }
 .sdoc-mark-neutral  { background-color: rgba(59, 130, 195, 0.15); color: #245d8a; }
-.sdoc-mark-warning  { background-color: rgba(200, 150, 30, 0.18); color: #7a5f0e; }
+.sdoc-mark-caution  { background-color: rgba(200, 150, 30, 0.18); color: #7a5f0e; }
+.sdoc-mark-warning  { background-color: rgba(255, 120, 0, 0.18); color: #b35400; }
 .sdoc-mark-negative { background-color: rgba(187, 50, 50, 0.15); color: #911e1e; }
 .sdoc-mark-highlight { background-color: rgba(255, 255, 0, 0.75); }
 

--- a/lexica/sdoc-authoring.sdoc
+++ b/lexica/sdoc-authoring.sdoc
@@ -181,7 +181,8 @@
                 \`\$\$E = mc^2\$\$\` | Display math (centered)
                 \`\{+text+\}\` | Positive marker (green)
                 \`\{=text=\}\` | Neutral marker (blue)
-                \`\{!text!\}\` | Warning marker (amber)
+                \`\{^text^\}\` | Caution marker (amber)
+                \`\{!text!\}\` | Warning marker (orange)
                 \`\{-text-\}\` | Negative marker (red)
                 \`\{~text~\}\` | Highlight (yellow)
             }
@@ -353,7 +354,7 @@
         {
             Backslash escapes special characters: \`\\\\\` \`\\{\` \`\\}\` \`\\@\`
             \`\\[\` \`\\]\` \`\\(\` \`\\)\` \`\\*\` \`\\~\` \`\\#\` \`\\!\` \`\\\<\`
-            \`\\\>\` \`\\\$\` \`\\+\` \`\\=\` \`\\-\`
+            \`\\\>\` \`\\\$\` \`\\+\` \`\\=\` \`\\-\` \`\\^\`
 
             A line starting with \`\\#\` renders as a literal \`#\` (not a heading). Use \`\\\$\` to prevent a dollar sign from starting math mode.
         }

--- a/lexica/specification.sdoc
+++ b/lexica/specification.sdoc
@@ -454,7 +454,8 @@ Content of Section B.
                 - Display math: `$$E = mc^2$$` (centered block)
                 - Positive marker: `{+text+}` (green highlight)
                 - Neutral marker: `{=text=}` (blue highlight)
-                - Warning marker: `{!text!}` (amber highlight)
+                - Caution marker: `{^text^}` (amber highlight)
+                - Warning marker: `{!text!}` (orange highlight)
                 - Negative marker: `{-text-}` (red highlight)
                 - Highlight: `{~text~}` (yellow highlight)
             }
@@ -464,7 +465,7 @@ Content of Section B.
 
         # Escaping @escaping
         {
-            In normal text (including headings and paragraphs), a backslash escapes: `\\` `\{` `\}` `\@` `\[` `\]` `\(` `\)` `\*` `\~` `\#` `\!` `\<` `\>` `\$` `\+` `\=` `\-` and `` \` ``.
+            In normal text (including headings and paragraphs), a backslash escapes: `\\` `\{` `\}` `\@` `\[` `\]` `\(` `\)` `\*` `\~` `\#` `\!` `\<` `\>` `\$` `\+` `\=` `\-` `\^` and `` \` ``.
 
             Escapes are processed before reference detection.
 
@@ -788,7 +789,7 @@ Content of Section A.
             - Comment syntax (if any)
             - Duplicate ID resolution (error vs warning vs nearest-scope)
             - Additional list types (checkboxes, alpha, roman)
-            - Additional inline formatting (underline, highlight)
+            - Additional inline formatting (underline)
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sdoc",
   "displayName": "SDOC",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "publisher": "entropicwarrior",
   "license": "MIT",
   "repository": {
@@ -113,6 +113,26 @@
     "configurationDefaults": {
       "[sdoc]": {
         "editor.wordWrap": "on"
+      },
+      "editor.tokenColorCustomizations": {
+        "textMateRules": [
+          {
+            "scope": "markup.quote.sdoc",
+            "settings": { "foreground": "#3b82c3" }
+          },
+          {
+            "scope": "markup.changed.sdoc",
+            "settings": { "foreground": "#b08a1a" }
+          },
+          {
+            "scope": "markup.keyword.warning.sdoc",
+            "settings": { "foreground": "#d97706" }
+          },
+          {
+            "scope": "markup.other.highlight.sdoc",
+            "settings": { "foreground": "#a68a00" }
+          }
+        ]
       }
     },
     "languageModelTools": [

--- a/src/notion-renderer.js
+++ b/src/notion-renderer.js
@@ -139,6 +139,7 @@ function flattenInlineNodes(nodes, annotations, href) {
         break;
       case "mark_positive":
       case "mark_neutral":
+      case "mark_caution":
       case "mark_warning":
       case "mark_negative":
       case "mark_highlight":

--- a/src/sdoc.js
+++ b/src/sdoc.js
@@ -8,7 +8,7 @@ const COMMAND_LIST_NUMBER = "{[#]";
 const COMMAND_TABLE = "{[table]";
 const COMMAND_CODE_FENCE = "```";
 
-const ESCAPABLE = new Set(["\\", "{", "}", "@", "[", "]", "(", ")", "*", "`", "#", "!", "~", "<", ">", "$", "+", "=", "-"]);
+const ESCAPABLE = new Set(["\\", "{", "}", "@", "[", "]", "(", ")", "*", "`", "#", "!", "~", "<", ">", "$", "+", "=", "-", "^"]);
 
 let _katex = null;
 let _katexLoaded = false;
@@ -1205,6 +1205,7 @@ function parseInline(text) {
       let mt = null;
       if (mc === "+") mt = "mark_positive";
       else if (mc === "=") mt = "mark_neutral";
+      else if (mc === "^") mt = "mark_caution";
       else if (mc === "!") mt = "mark_warning";
       else if (mc === "-") mt = "mark_negative";
       else if (mc === "~") mt = "mark_highlight";
@@ -1365,6 +1366,8 @@ function renderInlineNodes(nodes) {
           return `<span class="sdoc-mark sdoc-mark-positive">${renderInlineNodes(node.children)}</span>`;
         case "mark_neutral":
           return `<span class="sdoc-mark sdoc-mark-neutral">${renderInlineNodes(node.children)}</span>`;
+        case "mark_caution":
+          return `<span class="sdoc-mark sdoc-mark-caution">${renderInlineNodes(node.children)}</span>`;
         case "mark_warning":
           return `<span class="sdoc-mark sdoc-mark-warning">${renderInlineNodes(node.children)}</span>`;
         case "mark_negative":
@@ -1928,7 +1931,8 @@ const DEFAULT_STYLE = `
   }
   .sdoc-mark-positive { background-color: rgba(34, 139, 34, 0.15); color: #166016; }
   .sdoc-mark-neutral  { background-color: rgba(59, 130, 195, 0.15); color: #245d8a; }
-  .sdoc-mark-warning  { background-color: rgba(200, 150, 30, 0.18); color: #7a5f0e; }
+  .sdoc-mark-caution  { background-color: rgba(200, 150, 30, 0.18); color: #7a5f0e; }
+  .sdoc-mark-warning  { background-color: rgba(255, 120, 0, 0.18); color: #b35400; }
   .sdoc-mark-negative { background-color: rgba(187, 50, 50, 0.15); color: #911e1e; }
   .sdoc-mark-highlight { background-color: rgba(255, 255, 0, 0.75); }
 

--- a/syntaxes/sdoc.tmLanguage.json
+++ b/syntaxes/sdoc.tmLanguage.json
@@ -86,13 +86,14 @@
         { "include": "#strikethrough" },
         { "include": "#mark-positive" },
         { "include": "#mark-neutral" },
+        { "include": "#mark-caution" },
         { "include": "#mark-warning" },
         { "include": "#mark-negative" },
         { "include": "#mark-highlight" }
       ]
     },
     "escape": {
-      "match": "\\\\[\\\\{}@\\[\\]()*`#!~<>$+=-]",
+      "match": "\\\\[\\\\{}@\\[\\]()*`#!~<>$+=\\-^]",
       "name": "constant.character.escape.sdoc"
     },
     "reference": {
@@ -150,9 +151,13 @@
       "match": "\\{=(.+?)=\\}",
       "name": "markup.quote.sdoc"
     },
+    "mark-caution": {
+      "match": "\\{\\^(.+?)\\^\\}",
+      "name": "markup.changed.sdoc"
+    },
     "mark-warning": {
       "match": "\\{!(.+?)!\\}",
-      "name": "markup.changed.sdoc"
+      "name": "markup.keyword.warning.sdoc"
     },
     "mark-negative": {
       "match": "\\{-(.+?)-\\}",

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -1788,9 +1788,14 @@ test("neutral marker renders with correct class", () => {
   assert(html.includes("sdoc-mark-neutral") && html.includes(">info</span>"), "should render neutral marker");
 });
 
+test("caution marker renders with correct class", () => {
+  const html = renderHtmlDocument("# T\n{\nNote: {^caution^}\n}", "Test");
+  assert(html.includes("sdoc-mark-caution") && html.includes(">caution</span>"), "should render caution marker");
+});
+
 test("warning marker renders with correct class", () => {
-  const html = renderHtmlDocument("# T\n{\nNote: {!caution!}\n}", "Test");
-  assert(html.includes("sdoc-mark-warning") && html.includes(">caution</span>"), "should render warning marker");
+  const html = renderHtmlDocument("# T\n{\nAlert: {!warning!}\n}", "Test");
+  assert(html.includes("sdoc-mark-warning") && html.includes(">warning</span>"), "should render warning marker");
 });
 
 test("negative marker renders with correct class", () => {
@@ -1826,8 +1831,9 @@ test("marker uses <mark> element", () => {
 });
 
 test("multiple markers on one line", () => {
-  const html = renderHtmlDocument("# T\n{\nResults: {+pass+} and {-fail-}\n}", "Test");
+  const html = renderHtmlDocument("# T\n{\nResults: {+pass+} and {^careful^} and {-fail-}\n}", "Test");
   assert(html.includes("sdoc-mark-positive"), "should have positive marker");
+  assert(html.includes("sdoc-mark-caution"), "should have caution marker");
   assert(html.includes("sdoc-mark-negative"), "should have negative marker");
 });
 
@@ -1840,6 +1846,7 @@ test("parseInline produces correct node types for markers", () => {
   const types = [
     ["{+text+}", "mark_positive"],
     ["{=text=}", "mark_neutral"],
+    ["{^text^}", "mark_caution"],
     ["{!text!}", "mark_warning"],
     ["{-text-}", "mark_negative"],
     ["{~text~}", "mark_highlight"],


### PR DESCRIPTION
## Summary

- New `{^text^}` **caution** marker (muted amber) — takes over the existing warning color
- `{!text!}` **warning** marker now renders **bright orange** for higher severity
- 6-level marker system: positive, neutral, caution, warning, negative, highlight
- Editor syntax highlighting colors for all markers via `tokenColorCustomizations`
- `^` added to ESCAPABLE set and all escape documentation
- Version bump to 0.1.11

## Test plan
- [x] `node test/test-all.js` — 237 tests pass
- [x] `node test/test-notion.js` — 55 tests pass
- [ ] Preview all 6 markers in VS Code — each shows distinct color
- [ ] Verify editor syntax highlighting colors for all markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)