### PR TITLE
Add document PDF export and improve export UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A plain-text documentation format designed for AI-agent efficiency. Explicit bra
 
 **A document site builder** — serve a folder of SDOC files as a browsable site with sidebar navigation, search, and split-pane comparison.
 
+**PDF and HTML export** — export any document to A4 PDF via headless Chrome, or to standalone HTML. Available as both a CLI tool and a VS Code command.
+
 **A VS Code extension** — live preview, sticky scroll, code folding, document symbols, mermaid rendering, and commands for all the above.
 
 ## Quick Start
@@ -40,6 +42,15 @@ node tools/build-slides.js deck.sdoc -o slides.html
 ```
 
 Each top-level scope becomes a slide. Set `type: slides` in `@meta`. See `lexica/slide-authoring.sdoc` for the full authoring guide.
+
+### Export to PDF or HTML
+
+```bash
+node tools/build-doc.js doc.sdoc                   # PDF (requires Chrome)
+node tools/build-doc.js doc.sdoc --html -o doc.html # HTML
+```
+
+Or use **SDOC: Export PDF** / **SDOC: Export HTML** from the VS Code Command Palette.
 
 ### Browse documents
 

--- a/docs/guide/setup.sdoc
+++ b/docs/guide/setup.sdoc
@@ -62,14 +62,15 @@ code --install-extension dist/sdoc-*.vsix
 
     # Export and Print
     {
-        Two commands are available from the Command Palette when a preview is active:
+        Three export commands are available from the Command Palette or the editor title bar when an `.sdoc` file is open:
 
         {[.]
             - **SDOC: Export HTML** -- saves a standalone `.html` file with all styles embedded
+            - **SDOC: Export PDF** -- exports the document as an A4 PDF via headless Chrome
             - **SDOC: Open in Browser** -- opens the document in the system browser
         }
 
-        Both outputs support collapsible scope toggles. For PDF export, use the browser's print function (Ctrl+P / Cmd+P).
+        HTML and browser outputs support collapsible scope toggles. PDF export requires Chrome or Chromium installed on the system. For command-line export, see `tools/build-doc.js` in the [CLI reference](../reference/cli.sdoc).
     }
 
     # Configuration

--- a/docs/reference/api.sdoc
+++ b/docs/reference/api.sdoc
@@ -18,7 +18,7 @@ npm install @entropicwarrior/sdoc
 const { parseSdoc, extractMeta } = require("@entropicwarrior/sdoc");
 const { renderNotionBlocks } = require("@entropicwarrior/sdoc/notion");
 const { renderSlides } = require("@entropicwarrior/sdoc/slides");
-const { exportPdf } = require("@entropicwarrior/sdoc/slide-pdf");
+const { exportSlidePdf, exportDocPdf } = require("@entropicwarrior/sdoc/slide-pdf");
 const { knowledgeDir } = require("@entropicwarrior/sdoc/knowledge");
         ```
     }
@@ -170,5 +170,39 @@ await resolveIncludes(parsed.nodes, async (src) => {
         }
 
         Inline image nodes (`type: "image"`) within paragraphs include `src`, `alt`, and optional `width` (e.g. `"50%"`) and `align` (`"center"`, `"left"`, or `"right"`).
+    }
+
+    # exportSlidePdf(htmlPath, pdfPath)
+    {
+        Exports an HTML file to PDF using headless Chrome with 16:9 landscape dimensions (slide format).
+
+        ```javascript
+const { exportSlidePdf } = require("@entropicwarrior/sdoc/slide-pdf");
+await exportSlidePdf("/tmp/slides.html", "/tmp/slides.pdf");
+        ```
+
+        {[.]
+            - `htmlPath` -- path to the HTML file to convert
+            - `pdfPath` -- path for the output PDF
+            - Returns a Promise that resolves with the output path
+            - Requires Chrome or Chromium (auto-detected, or set `CHROME_PATH`)
+        }
+    }
+
+    # exportDocPdf(htmlPath, pdfPath)
+    {
+        Exports an HTML file to PDF using headless Chrome with A4 portrait dimensions (document format).
+
+        ```javascript
+const { exportDocPdf } = require("@entropicwarrior/sdoc/slide-pdf");
+await exportDocPdf("/tmp/document.html", "/tmp/document.pdf");
+        ```
+
+        {[.]
+            - `htmlPath` -- path to the HTML file to convert
+            - `pdfPath` -- path for the output PDF
+            - Returns a Promise that resolves with the output path
+            - Uses A4 paper (8.27 x 11.69 inches) with print-optimized styles
+        }
     }
 }

--- a/docs/reference/cli.sdoc
+++ b/docs/reference/cli.sdoc
@@ -6,13 +6,14 @@
 
     # VSCode Extension Commands
     {
-        The SDOC extension registers seven commands, available from the Command Palette:
+        The SDOC extension registers eight commands, available from the Command Palette:
 
         {[.]
             - **SDOC: Open Preview** (`sdoc.preview`) -- opens a rendered preview of the current `.sdoc` file
             - **SDOC: Open Preview to the Side** (`sdoc.previewToSide`) -- opens the preview in a side pane
-            - **SDOC: Export HTML** (`sdoc.exportHtml`) -- exports the active preview as a standalone HTML file
-            - **SDOC: Open in Browser** (`sdoc.openInBrowser`) -- opens the active preview in the system browser
+            - **SDOC: Export HTML** (`sdoc.exportHtml`) -- exports the current document as a standalone HTML file
+            - **SDOC: Export PDF** (`sdoc.exportPdf`) -- exports the current document as an A4 PDF via headless Chrome
+            - **SDOC: Open in Browser** (`sdoc.openInBrowser`) -- opens the current document in the system browser
             - **SDOC: Browse Documents** (`sdoc.browseDocs`) -- starts a local document server and opens the viewer in a browser
             - **SDOC: New Knowledge File** (`sdoc.newKnowledgeFile`) -- creates a new `.sdoc` file from a template in the selected folder
             - **SDOC: Generate About** (`sdoc.generateAbout`) -- generates an About section for the current document
@@ -27,13 +28,43 @@
 
         # Export HTML
         {
-            Exports the currently previewed document as a self-contained `.html` file. The exported file includes all styles and supports collapsible scope toggles in the browser. Use the browser's print function (Ctrl+P / Cmd+P) for PDF export.
+            Exports the current SDOC document as a self-contained `.html` file. Works from the editor or the preview panel. The exported file includes all styles and supports collapsible scope toggles in the browser.
+        }
+
+        # Export PDF
+        {
+            Exports the current SDOC document as an A4 PDF. Works from the editor or the preview panel. Requires Google Chrome or Chromium installed on the system (or set the `CHROME_PATH` environment variable). The PDF uses print-optimized styles with correct font sizes and preserved marker colors.
         }
 
         # Open in Browser
         {
-            Opens the currently previewed document in the system's default browser. A temporary HTML file is created and opened. Like Export HTML, the output supports collapsible toggles and printing.
+            Opens the current SDOC document in the system's default browser. Works from the editor or the preview panel. A temporary HTML file is created and opened. Like Export HTML, the output supports collapsible toggles and printing.
         }
+    }
+
+    # Build Document Tool
+    {
+        `tools/build-doc.js` exports SDOC files to HTML or PDF from the command line.
+
+        ```bash
+node tools/build-doc.js input.sdoc                   # PDF output (default)
+node tools/build-doc.js input.sdoc -o output.pdf      # PDF with custom path
+node tools/build-doc.js input.sdoc --html             # HTML output
+node tools/build-doc.js input.sdoc --html -o out.html  # HTML with custom path
+        ```
+
+        # Options
+        {
+            {[.]
+                - `-o <path>` -- output file path (default: input name with `.pdf` or `.html` extension)
+                - `--html` -- export as HTML instead of PDF
+                - `--help` / `-h` -- show usage information and exit
+            }
+        }
+
+        PDF export requires Google Chrome or Chromium. Set the `CHROME_PATH` environment variable to override auto-detection. The output uses A4 page size with print-optimized styles.
+
+        The tool respects `sdoc.config.json` files in the directory hierarchy and per-file `@meta` style overrides, just like the VS Code extension.
     }
 
     # Notion Sync Tool

--- a/lexica/status.sdoc
+++ b/lexica/status.sdoc
@@ -79,7 +79,9 @@
             - [x] Interactive preview: inline text editing (edit paragraphs directly in preview)
             - [x] Parser line tracking (lineStart/lineEnd on all AST nodes)
             - [x] Export HTML (sdoc.exportHtml) -- standalone HTML with collapsible toggles
+            - [x] Export PDF (sdoc.exportPdf) -- A4 PDF via headless Chrome
             - [x] Open in Browser (sdoc.openInBrowser) -- preview in system browser
+            - [x] Document export CLI (tools/build-doc.js) -- HTML and PDF export from command line
             - [x] Document formatter (Format Document / Shift+Option+F) -- auto-indent based on brace depth
             - [x] AI skill reference tool (sdoc_reference) -- returns SDOC format guide to language models with reading guidance preamble
             - [x] New Knowledge File command (sdoc.newKnowledgeFile) -- creates skeleton .sdoc knowledge file from explorer context menu or command palette

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sdoc",
   "displayName": "SDOC",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "publisher": "entropicwarrior",
   "license": "MIT",
   "repository": {
@@ -42,6 +42,7 @@
     "onCommand:sdoc.preview",
     "onCommand:sdoc.previewToSide",
     "onCommand:sdoc.exportHtml",
+    "onCommand:sdoc.exportPdf",
     "onCommand:sdoc.openInBrowser",
     "onCommand:sdoc.browseDocs",
     "onCommand:sdoc.newKnowledgeFile",
@@ -86,6 +87,11 @@
         "command": "sdoc.exportHtml",
         "title": "SDOC: Export HTML",
         "icon": "$(desktop-download)"
+      },
+      {
+        "command": "sdoc.exportPdf",
+        "title": "SDOC: Export PDF",
+        "icon": "$(file-pdf)"
       },
       {
         "command": "sdoc.openInBrowser",
@@ -160,12 +166,17 @@
         },
         {
           "command": "sdoc.exportHtml",
-          "when": "activeWebviewPanelId == 'sdoc.preview'",
+          "when": "activeWebviewPanelId == 'sdoc.preview' || editorLangId == sdoc",
+          "group": "navigation"
+        },
+        {
+          "command": "sdoc.exportPdf",
+          "when": "activeWebviewPanelId == 'sdoc.preview' || editorLangId == sdoc",
           "group": "navigation"
         },
         {
           "command": "sdoc.openInBrowser",
-          "when": "activeWebviewPanelId == 'sdoc.preview'",
+          "when": "activeWebviewPanelId == 'sdoc.preview' || editorLangId == sdoc",
           "group": "navigation"
         }
       ],

--- a/src/extension.js
+++ b/src/extension.js
@@ -53,6 +53,10 @@ function activate(context) {
     exportHtml();
   });
 
+  const exportPdfCommand = vscode.commands.registerCommand("sdoc.exportPdf", () => {
+    exportPdfDoc();
+  });
+
   const openInBrowserCommand = vscode.commands.registerCommand("sdoc.openInBrowser", () => {
     openInBrowser();
   });
@@ -300,7 +304,7 @@ function activate(context) {
     await vscode.workspace.applyEdit(editBuilder);
   });
 
-  context.subscriptions.push(previewCommand, previewToSideCommand, previewFromExplorerCommand, exportHtmlCommand, openInBrowserCommand, browseDocsCommand, newKnowledgeFileCommand, generateAboutCommand);
+  context.subscriptions.push(previewCommand, previewToSideCommand, previewFromExplorerCommand, exportHtmlCommand, exportPdfCommand, openInBrowserCommand, browseDocsCommand, newKnowledgeFileCommand, generateAboutCommand);
 
   context.subscriptions.push(
     vscode.languages.registerDocumentSymbolProvider("sdoc", {
@@ -1131,6 +1135,11 @@ function getActivePreviewDocument() {
       return vscode.workspace.openTextDocument(vscode.Uri.parse(key));
     }
   }
+  // Fall back to the active editor if it's an .sdoc file
+  const editor = vscode.window.activeTextEditor;
+  if (editor && editor.document.languageId === "sdoc") {
+    return Promise.resolve(editor.document);
+  }
   return null;
 }
 
@@ -1220,7 +1229,7 @@ async function buildCleanHtml(document) {
 async function exportHtml() {
   const docPromise = getActivePreviewDocument();
   if (!docPromise) {
-    vscode.window.showInformationMessage("No SDOC preview is active.");
+    vscode.window.showInformationMessage("No SDOC document is open.");
     return;
   }
 
@@ -1242,10 +1251,43 @@ async function exportHtml() {
   vscode.window.showInformationMessage(`Exported: ${path.basename(target.fsPath)}`);
 }
 
+async function exportPdfDoc() {
+  const docPromise = getActivePreviewDocument();
+  if (!docPromise) {
+    vscode.window.showInformationMessage("No SDOC document is open.");
+    return;
+  }
+
+  const document = await docPromise;
+  const baseName = path.basename(document.uri.fsPath, ".sdoc") + ".pdf";
+  const defaultUri = vscode.Uri.file(path.join(path.dirname(document.uri.fsPath), baseName));
+
+  const target = await vscode.window.showSaveDialog({
+    defaultUri,
+    filters: { "PDF": ["pdf"] }
+  });
+
+  if (!target) return;
+
+  const html = await buildCleanHtml(document);
+  const tmpHtml = path.join(os.tmpdir(), "sdoc-pdf-" + Date.now() + ".html");
+  fs.writeFileSync(tmpHtml, html, "utf8");
+
+  try {
+    const { exportDocPdf } = require("./slide-pdf");
+    await exportDocPdf(tmpHtml, target.fsPath);
+    vscode.window.showInformationMessage(`Exported: ${path.basename(target.fsPath)}`);
+  } catch (err) {
+    vscode.window.showErrorMessage(`PDF export failed: ${err.message}`);
+  } finally {
+    try { fs.unlinkSync(tmpHtml); } catch {}
+  }
+}
+
 async function openInBrowser() {
   const docPromise = getActivePreviewDocument();
   if (!docPromise) {
-    vscode.window.showInformationMessage("No SDOC preview is active.");
+    vscode.window.showInformationMessage("No SDOC document is open.");
     return;
   }
 

--- a/src/slide-pdf.js
+++ b/src/slide-pdf.js
@@ -1,4 +1,4 @@
-// SDOC Slides — PDF export via headless Chrome.
+// SDOC — PDF export via headless Chrome.
 // Zero dependencies: uses child_process to shell out to the system Chrome/Chromium.
 
 const { execFile } = require("child_process");
@@ -51,7 +51,11 @@ function findChrome() {
   return null;
 }
 
-function exportPdf(htmlPath, pdfPath) {
+// Generic PDF export. Options:
+//   paperWidth  — inches (default 8.27 = A4)
+//   paperHeight — inches (default 11.69 = A4)
+//   noHeaderFooter — suppress Chrome header/footer (default true)
+function chromePdf(htmlPath, pdfPath, options = {}) {
   return new Promise((resolve, reject) => {
     const chrome = findChrome();
     if (!chrome) {
@@ -69,19 +73,25 @@ function exportPdf(htmlPath, pdfPath) {
     // the browser process by default, which corrupts PDF output).
     const tmpProfile = fs.mkdtempSync(path.join(os.tmpdir(), "sdoc-chrome-"));
 
-    // 13.333 x 7.5 inches = 16:9 landscape (standard presentation aspect ratio)
+    const paperWidth = options.paperWidth ?? 8.27;
+    const paperHeight = options.paperHeight ?? 11.69;
+
     const args = [
       "--headless=new",
       "--disable-gpu",
       "--no-first-run",
       "--no-default-browser-check",
       "--user-data-dir=" + tmpProfile,
-      "--no-pdf-header-footer",
       "--print-to-pdf=" + resolvedPdf,
-      "--print-to-pdf-paper-width=13.333",
-      "--print-to-pdf-paper-height=7.5",
-      fileUrl,
+      "--print-to-pdf-paper-width=" + paperWidth,
+      "--print-to-pdf-paper-height=" + paperHeight,
     ];
+
+    if (options.noHeaderFooter !== false) {
+      args.push("--no-pdf-header-footer");
+    }
+
+    args.push(fileUrl);
 
     execFile(chrome, args, { timeout: 30000 }, (err, _stdout, stderr) => {
       // Clean up temp profile
@@ -96,4 +106,14 @@ function exportPdf(htmlPath, pdfPath) {
   });
 }
 
-module.exports = { findChrome, exportPdf };
+// Slide PDF: 16:9 landscape (13.333 x 7.5 inches)
+function exportSlidePdf(htmlPath, pdfPath) {
+  return chromePdf(htmlPath, pdfPath, { paperWidth: 13.333, paperHeight: 7.5 });
+}
+
+// Document PDF: A4 portrait (8.27 x 11.69 inches)
+function exportDocPdf(htmlPath, pdfPath) {
+  return chromePdf(htmlPath, pdfPath);
+}
+
+module.exports = { findChrome, exportSlidePdf, exportDocPdf, chromePdf };

--- a/test/test-slides.js
+++ b/test/test-slides.js
@@ -459,7 +459,7 @@ test("findChrome returns a string or null", () => {
 });
 
 test("exportPdf produces a file (integration)", async () => {
-  const { exportPdf, findChrome } = require("../src/slide-pdf");
+  const { exportSlidePdf, findChrome } = require("../src/slide-pdf");
   if (!findChrome()) {
     console.log("    SKIP: Chrome not found");
     return;
@@ -480,7 +480,7 @@ test("exportPdf produces a file (integration)", async () => {
 
   fs.writeFileSync(tmpHtml, html, "utf-8");
   try {
-    await exportPdf(tmpHtml, tmpPdf);
+    await exportSlidePdf(tmpHtml, tmpPdf);
     assert(fs.existsSync(tmpPdf), "PDF file should exist");
     const stat = fs.statSync(tmpPdf);
     assert(stat.size > 0, "PDF should not be empty");

--- a/tools/build-doc.js
+++ b/tools/build-doc.js
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+// SDOC Document — CLI tool for HTML and PDF export
+//
+// Usage:
+//   node tools/build-doc.js input.sdoc [-o output] [--html]
+//
+// Default output is PDF (requires Chrome/Chromium).
+// Use --html for HTML-only output (no Chrome needed).
+// If -o is omitted, writes to input.pdf (or input.html with --html).
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { parseSdoc, extractMeta, resolveIncludes, renderHtmlDocumentFromParsed } = require("../src/sdoc");
+
+const CONFIG_FILENAME = "sdoc.config.json";
+
+function usage() {
+  console.error("Usage: build-doc <input.sdoc> [-o output] [--html]");
+  process.exit(1);
+}
+
+function readJson(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function loadCss(filePath) {
+  if (!filePath) return null;
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function resolvePath(baseDir, target) {
+  if (!target) return "";
+  if (path.isAbsolute(target)) return target;
+  return path.join(baseDir, target);
+}
+
+function mergeConfig(target, config, baseDir) {
+  if (!config || typeof config !== "object") return;
+  if (typeof config.style === "string") {
+    target.style = resolvePath(baseDir, config.style);
+  }
+  if (config.styleAppend) {
+    const list = Array.isArray(config.styleAppend) ? config.styleAppend : [config.styleAppend];
+    for (const item of list) {
+      if (typeof item === "string") {
+        target.styleAppend.push(resolvePath(baseDir, item));
+      }
+    }
+  }
+  if (typeof config.header === "string") target.header = config.header;
+  if (typeof config.footer === "string") target.footer = config.footer;
+}
+
+function loadConfigForFile(filePath) {
+  const startDir = path.dirname(path.resolve(filePath));
+  const root = path.parse(startDir).root;
+  const chain = [];
+  let current = startDir;
+
+  while (current) {
+    const configPath = path.join(current, CONFIG_FILENAME);
+    if (fs.existsSync(configPath)) {
+      const parsed = readJson(configPath);
+      if (parsed) chain.push({ dir: current, config: parsed });
+    }
+    if (current === root) break;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  const merged = { style: null, styleAppend: [], header: "", footer: "" };
+  for (const entry of chain.reverse()) {
+    mergeConfig(merged, entry.config, entry.dir);
+  }
+  return merged;
+}
+
+function resolveMetaStyles(meta, documentPath) {
+  const docDir = documentPath ? path.dirname(documentPath) : "";
+  const result = { styleCss: null, styleAppendCss: null };
+  if (meta && meta.stylePath) {
+    result.styleCss = loadCss(resolvePath(docDir, meta.stylePath));
+  }
+  if (meta && meta.styleAppendPath) {
+    result.styleAppendCss = loadCss(resolvePath(docDir, meta.styleAppendPath));
+  }
+  return result;
+}
+
+async function buildHtml(filePath) {
+  const resolvedPath = path.resolve(filePath);
+  const text = fs.readFileSync(resolvedPath, "utf8");
+  const parsed = parseSdoc(text);
+
+  if (parsed.errors.length > 0) {
+    for (const error of parsed.errors) {
+      console.error(`Warning: line ${error.line}: ${error.message}`);
+    }
+  }
+
+  const metaResult = extractMeta(parsed.nodes);
+  const config = loadConfigForFile(resolvedPath);
+  const metaStyles = resolveMetaStyles(metaResult.meta, resolvedPath);
+
+  const docDir = path.dirname(resolvedPath);
+  await resolveIncludes(metaResult.nodes, (src) => {
+    const resolved = resolvePath(docDir, src);
+    return fs.readFileSync(resolved, "utf8");
+  });
+
+  const cssOverride = metaStyles.styleCss ?? loadCss(config.style);
+  const cssAppendParts = [];
+  if (config.styleAppend && config.styleAppend.length) {
+    for (const stylePath of config.styleAppend) {
+      const css = loadCss(stylePath);
+      if (css) cssAppendParts.push(css);
+    }
+  }
+  if (metaStyles.styleAppendCss) {
+    cssAppendParts.push(metaStyles.styleAppendCss);
+  }
+
+  const title = path.basename(resolvedPath, ".sdoc");
+
+  return renderHtmlDocumentFromParsed(
+    { nodes: metaResult.nodes, errors: parsed.errors },
+    title,
+    {
+      meta: metaResult.meta,
+      config,
+      cssOverride: cssOverride || undefined,
+      cssAppend: cssAppendParts.join("\n") || undefined,
+    }
+  );
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let inputPath = null;
+  let outputPath = null;
+  let htmlMode = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-o" && i + 1 < args.length) {
+      outputPath = args[++i];
+    } else if (args[i] === "--html") {
+      htmlMode = true;
+    } else if (args[i] === "--help" || args[i] === "-h") {
+      usage();
+    } else if (!inputPath) {
+      inputPath = args[i];
+    } else {
+      console.error(`Unknown argument: ${args[i]}`);
+      usage();
+    }
+  }
+
+  if (!inputPath) usage();
+
+  const resolvedInput = path.resolve(inputPath);
+  if (!fs.existsSync(resolvedInput)) {
+    console.error(`File not found: ${resolvedInput}`);
+    process.exit(1);
+  }
+
+  const html = await buildHtml(resolvedInput);
+
+  if (htmlMode) {
+    if (!outputPath) {
+      outputPath = resolvedInput.replace(/\.sdoc$/i, "") + ".html";
+    }
+    const resolvedOutput = path.resolve(outputPath);
+    fs.mkdirSync(path.dirname(resolvedOutput), { recursive: true });
+    fs.writeFileSync(resolvedOutput, html, "utf-8");
+    console.log(`HTML: ${resolvedOutput}`);
+  } else {
+    const { exportDocPdf } = require("../src/slide-pdf");
+
+    if (!outputPath) {
+      outputPath = resolvedInput.replace(/\.sdoc$/i, "") + ".pdf";
+    }
+    const resolvedOutput = path.resolve(outputPath);
+
+    // Write HTML to temp file for Chrome
+    const tmpHtml = path.join(os.tmpdir(), "sdoc-doc-" + Date.now() + ".html");
+    fs.writeFileSync(tmpHtml, html, "utf-8");
+
+    try {
+      await exportDocPdf(tmpHtml, resolvedOutput);
+      console.log(`PDF: ${resolvedOutput}`);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    } finally {
+      try { fs.unlinkSync(tmpHtml); } catch {}
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/tools/build-slides.js
+++ b/tools/build-slides.js
@@ -98,7 +98,7 @@ async function main() {
   const html = renderSlides(nodes, { meta, themeCss, themeJs, darkMode });
 
   if (pdfMode) {
-    const { exportPdf } = require("../src/slide-pdf");
+    const { exportSlidePdf } = require("../src/slide-pdf");
 
     // Determine PDF output path
     let pdfOutput;
@@ -113,7 +113,7 @@ async function main() {
     fs.writeFileSync(tmpHtml, html, "utf-8");
 
     try {
-      await exportPdf(tmpHtml, pdfOutput);
+      await exportSlidePdf(tmpHtml, pdfOutput);
       console.log(`PDF: ${pdfOutput}`);
     } catch (err) {
       console.error(err.message);


### PR DESCRIPTION
## Summary

- **Document PDF export**: A4 PDF output via headless Chrome, available as a VS Code command (`SDOC: Export PDF`) and a CLI tool (`tools/build-doc.js`)
- **Refactored PDF engine**: `slide-pdf.js` now exposes `chromePdf()` with configurable paper size, `exportSlidePdf()` for 16:9 slides, and `exportDocPdf()` for A4 documents
- **Better export UX**: Export HTML, Export PDF, and Open in Browser now work directly from the editor — no active preview panel required
- **Version bump**: 0.1.11 → 0.1.12

## Test plan

- [x] All 337 tests pass (241 parser + 41 slides + 55 notion)
- [x] `node tools/build-doc.js examples/example.sdoc -o /tmp/test.pdf` produces A4 PDF
- [x] `node tools/build-doc.js examples/example.sdoc --html -o /tmp/test.html` produces HTML
- [x] `node tools/build-slides.js examples/mermaid-example.sdoc --pdf -o /tmp/test.pdf` still works (backwards compat)
- [x] Extension rebuilt and installed — Export PDF command works from editor and preview
- [x] Verify Export HTML and Open in Browser work from editor without preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)