### PR TITLE
Fix .npmignore to exclude unneeded docs from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,9 +4,12 @@
 .git/
 .gitignore
 .vscodeignore
-docs/
-!docs/reference/sdoc-authoring.sdoc
-!docs/reference/slide-authoring.sdoc
+docs/guide/
+docs/tutorials/
+docs/index.sdoc
+docs/reference/api.sdoc
+docs/reference/cli.sdoc
+docs/reference/syntax.sdoc
 examples/
 lexica/requirements.sdoc
 lexica/sdoc-plan.sdoc

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sdoc",
   "displayName": "SDOC",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "publisher": "entropicwarrior",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- npm's ignore logic doesn't support `!` negation to un-ignore files inside an ignored directory — v0.1.17 shipped with all 11 docs files instead of just the 2 authoring guides
- Replace `docs/` + `!exceptions` with specific directory/file excludes

## Test plan
- [x] `npm pack --dry-run` confirms only `docs/reference/sdoc-authoring.sdoc` and `docs/reference/slide-authoring.sdoc` are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)