### PR TITLE
Add broken reference and link detection

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -4,7 +4,7 @@ const os = require("os");
 const path = require("path");
 const url = require("url");
 const vscode = require("vscode");
-const { parseSdoc, extractMeta, resolveIncludes, renderHtmlDocumentFromParsed, slugify, listSections } = require("./sdoc");
+const { parseSdoc, extractMeta, resolveIncludes, renderHtmlDocumentFromParsed, slugify, listSections, validateRefs } = require("./sdoc");
 
 const PREVIEW_VIEW_TYPE = "sdoc.preview";
 const CONFIG_FILENAME = "sdoc.config.json";
@@ -14,6 +14,8 @@ const panels = new Map();
 let activeServer = null;  // { server, port, rootDir }
 let statusBarItem = null;
 const includeCache = new Map();
+let diagnosticCollection = null;
+let diagnosticTimer = null;
 
 function activate(context) {
   const previewCommand = vscode.commands.registerCommand("sdoc.preview", () => {
@@ -342,6 +344,9 @@ function activate(context) {
     })
   );
 
+  diagnosticCollection = vscode.languages.createDiagnosticCollection("sdoc");
+  context.subscriptions.push(diagnosticCollection);
+
   context.subscriptions.push(
     vscode.lm.registerTool('sdoc_reference', {
       async invoke(options, token) {
@@ -371,6 +376,8 @@ function activate(context) {
         return;
       }
       updatePreview(event.document);
+      if (diagnosticTimer) clearTimeout(diagnosticTimer);
+      diagnosticTimer = setTimeout(() => updateDiagnostics(event.document, false), 500);
     })
   );
 
@@ -380,6 +387,8 @@ function activate(context) {
       if (document.languageId === "sdoc") {
         includeCache.clear();
         updatePreview(document);
+        if (diagnosticTimer) { clearTimeout(diagnosticTimer); diagnosticTimer = null; }
+        updateDiagnostics(document, true);
         return;
       }
 
@@ -402,6 +411,9 @@ function activate(context) {
         panel.dispose();
         panels.delete(key);
       }
+      if (diagnosticCollection && document.languageId === "sdoc") {
+        diagnosticCollection.delete(document.uri);
+      }
     })
   );
 
@@ -410,6 +422,59 @@ function activate(context) {
       updateAllPreviews();
     })
   );
+}
+
+function updateDiagnostics(document, fullValidation) {
+  if (!diagnosticCollection) return;
+  const parsed = parseSdoc(document.getText());
+  const metaResult = extractMeta(parsed.nodes);
+  const docDir = path.dirname(document.uri.fsPath);
+
+  const options = {};
+  if (fullValidation) {
+    options.resolveFilePath = (href) => {
+      const absPath = path.isAbsolute(href) ? href : path.join(docDir, href);
+      return fs.existsSync(absPath);
+    };
+  }
+
+  const warnings = validateRefs(metaResult.nodes, options);
+  const lines = document.getText().split("\n");
+  const diagnostics = warnings.map((warning) => {
+    const range = findWarningRange(document, lines, warning);
+    const diagnostic = new vscode.Diagnostic(range, warning.message, vscode.DiagnosticSeverity.Error);
+    diagnostic.source = "sdoc";
+    return diagnostic;
+  });
+  diagnosticCollection.set(document.uri, diagnostics);
+}
+
+function findWarningRange(document, lines, warning) {
+  const startLine = Math.max(0, (warning.lineStart || 1) - 1);
+  const endLine = Math.min(lines.length - 1, (warning.lineEnd || warning.lineStart || 1) - 1);
+
+  for (let i = startLine; i <= endLine; i++) {
+    const line = lines[i];
+    if (warning.type === "broken-ref") {
+      // Skip heading lines to avoid matching @id declarations
+      if (/^\s*#/.test(line)) continue;
+      const token = "@" + warning.id;
+      const col = line.indexOf(token);
+      if (col !== -1) {
+        return new vscode.Range(i, col, i, col + token.length);
+      }
+    } else if (warning.type === "broken-link") {
+      const token = "](" + warning.href + ")";
+      const col = line.indexOf(token);
+      if (col !== -1) {
+        // Highlight just the href portion (skip the "](" prefix)
+        return new vscode.Range(i, col + 2, i, col + 2 + warning.href.length);
+      }
+    }
+  }
+
+  // Fallback: highlight entire first line of range
+  return new vscode.Range(startLine, 0, startLine, lines[startLine].length);
 }
 
 function deactivate() {
@@ -778,6 +843,12 @@ function darkModeElementsCss(prefix) {
   ${prefix} .sdoc-errors {
     background: rgba(187, 112, 68, 0.18);
     border-color: rgba(187, 112, 68, 0.5);
+  }
+
+  ${prefix} .sdoc-broken-ref, ${prefix} .sdoc-link.sdoc-broken-link {
+    color: #f77;
+    text-decoration-color: #f77;
+    background: rgba(255, 119, 119, 0.1);
   }`;
 }
 
@@ -885,6 +956,20 @@ async function buildHtml(document, title, webview) {
   const docDir = path.dirname(document.uri.fsPath);
   await resolveIncludes(metaResult.nodes, (src) => resolveIncludeSrc(src, docDir));
 
+  // Validate refs and links for preview indicators
+  const refWarnings = validateRefs(metaResult.nodes, {
+    resolveFilePath: (href) => {
+      const absPath = path.isAbsolute(href) ? href : path.join(docDir, href);
+      return fs.existsSync(absPath);
+    }
+  });
+  const brokenRefIds = new Set();
+  const brokenLinkHrefs = new Set();
+  for (const w of refWarnings) {
+    if (w.type === "broken-ref") brokenRefIds.add(w.id);
+    else if (w.type === "broken-link") brokenLinkHrefs.add(w.href);
+  }
+
   const cssOverride = metaStyles.styleCss ?? loadCss(config.style);
   const cssAppendParts = [];
   if (config.styleAppend && config.styleAppend.length) {
@@ -914,7 +999,7 @@ async function buildHtml(document, title, webview) {
       cssAppend: cssAppendParts.join("\n"),
       script: buildWebviewScript(),
       mermaidTheme: isDark ? "dark" : "neutral",
-      renderOptions: { editable: false }
+      renderOptions: { editable: false, brokenRefIds, brokenLinkHrefs }
     }
   );
 

--- a/src/sdoc.js
+++ b/src/sdoc.js
@@ -1379,6 +1379,9 @@ function renderInlineNodes(nodes) {
           return escapeHtml(node.value);
         case "ref": {
           const href = `#${escapeAttr(node.id)}`;
+          if (_renderOptions.brokenRefIds && _renderOptions.brokenRefIds.has(node.id)) {
+            return `<a class="sdoc-ref sdoc-broken-ref" href="${href}"><span class="sdoc-broken-icon">\u26A0</span>@${escapeHtml(node.id)}</a>`;
+          }
           return `<a class="sdoc-ref" href="${href}">@${escapeHtml(node.id)}</a>`;
         }
         case "code":
@@ -1404,6 +1407,11 @@ function renderInlineNodes(nodes) {
         case "mark_highlight":
           return `<mark class="sdoc-mark sdoc-mark-highlight">${renderInlineNodes(node.children)}</mark>`;
         case "link":
+          if (_renderOptions.brokenLinkHrefs && _renderOptions.brokenLinkHrefs.has(node.href)) {
+            return `<a class="sdoc-link sdoc-broken-link" href="${escapeAttr(node.href)}" target="_blank" rel="noopener noreferrer"><span class="sdoc-broken-icon">\u26A0</span>${renderInlineNodes(
+              node.children
+            )}</a>`;
+          }
           return `<a class="sdoc-link" href="${escapeAttr(node.href)}" target="_blank" rel="noopener noreferrer">${renderInlineNodes(
             node.children
           )}</a>`;
@@ -1981,6 +1989,19 @@ const DEFAULT_STYLE = `
   .sdoc-mark-negative  { background-color: rgba(210, 25, 25, 0.18); color: #a81414; }
   .sdoc-mark-highlight { background-color: rgba(255, 255, 0, 0.75); }
 
+  .sdoc-broken-ref, .sdoc-link.sdoc-broken-link {
+    color: #c33;
+    text-decoration: wavy underline #c33;
+    text-underline-offset: 2px;
+    background: rgba(204, 51, 51, 0.08);
+    border-radius: 2px;
+    padding: 0 0.15em;
+  }
+  .sdoc-broken-icon {
+    font-size: 0.75em;
+    margin-right: 0.15em;
+  }
+
   .sdoc-image {
     display: inline-block;
     max-width: 100%;
@@ -2443,6 +2464,127 @@ function extractAbout(nodes) {
   return null;
 }
 
+function collectAllIds(nodes) {
+  const ids = new Set();
+  function walk(nodeList) {
+    for (const node of nodeList) {
+      if (node.type === "scope") {
+        if (node.id) ids.add(node.id);
+        if (node.title) ids.add(slugify(node.title));
+      }
+      if (node.children) walk(node.children);
+      if (node.type === "list" && node.items) {
+        walk(node.items);
+      }
+    }
+  }
+  walk(nodes);
+  return ids;
+}
+
+function collectInlineRefs(nodes) {
+  const refs = [];
+  const links = [];
+
+  function walkInlineNodes(inlineNodes, lineStart, lineEnd) {
+    for (const node of inlineNodes) {
+      if (node.type === "ref") {
+        refs.push({ id: node.id, lineStart, lineEnd });
+      } else if (node.type === "link") {
+        links.push({ href: node.href, lineStart, lineEnd });
+      }
+      if (node.children) {
+        walkInlineNodes(node.children, lineStart, lineEnd);
+      }
+    }
+  }
+
+  function processText(text, lineStart, lineEnd) {
+    const inlineNodes = parseInline(text);
+    walkInlineNodes(inlineNodes, lineStart, lineEnd);
+  }
+
+  function walk(nodeList) {
+    for (const node of nodeList) {
+      if (node.type === "paragraph" && node.text) {
+        processText(node.text, node.lineStart, node.lineEnd);
+      } else if (node.type === "blockquote" && node.paragraphs) {
+        for (const para of node.paragraphs) {
+          processText(para, node.lineStart, node.lineEnd);
+        }
+      } else if (node.type === "scope") {
+        if (node.title) {
+          processText(node.title, node.lineStart, node.lineStart);
+        }
+        if (node.children) walk(node.children);
+      } else if (node.type === "list" && node.items) {
+        walk(node.items);
+      } else if (node.type === "table") {
+        if (node.headers) {
+          for (const cell of node.headers) {
+            processText(cell, node.lineStart, node.lineEnd);
+          }
+        }
+        if (node.rows) {
+          for (const row of node.rows) {
+            for (const cell of row) {
+              processText(cell, node.lineStart, node.lineEnd);
+            }
+          }
+        }
+      }
+      // Handle list items (no type field, but have title/children)
+      if (!node.type) {
+        if (node.title) processText(node.title, node.lineStart || 0, node.lineEnd || node.lineStart || 0);
+        if (node.children) walk(node.children);
+      }
+    }
+  }
+  walk(nodes);
+  return { refs, links };
+}
+
+function validateRefs(nodes, options = {}) {
+  const ids = collectAllIds(nodes);
+  const externalIds = options.externalIds || new Set();
+  const { refs, links } = collectInlineRefs(nodes);
+  const warnings = [];
+
+  for (const ref of refs) {
+    if (!ids.has(ref.id) && !externalIds.has(ref.id)) {
+      warnings.push({
+        type: "broken-ref",
+        id: ref.id,
+        message: `Broken reference: @${ref.id} does not match any scope ID or title`,
+        lineStart: ref.lineStart,
+        lineEnd: ref.lineEnd
+      });
+    }
+  }
+
+  for (const link of links) {
+    const href = link.href;
+    if (/^https?:\/\//i.test(href) || /^mailto:/i.test(href) || href.startsWith("#") || href.startsWith("data:")) {
+      continue;
+    }
+    if (options.resolveFilePath) {
+      const filePath = href.split("#")[0].split("?")[0];
+      if (!filePath) continue;
+      if (!options.resolveFilePath(filePath)) {
+        warnings.push({
+          type: "broken-link",
+          href,
+          message: `Broken link: file not found — ${href}`,
+          lineStart: link.lineStart,
+          lineEnd: link.lineEnd
+        });
+      }
+    }
+  }
+
+  return warnings;
+}
+
 async function resolveIncludes(nodes, resolverFn) {
   for (const node of nodes) {
     if (node.type === "code" && node.src) {
@@ -2490,6 +2632,10 @@ module.exports = {
   extractAbout,
   extractDataBlocks,
   KNOWN_SCOPE_TYPES,
+  // Validation
+  collectAllIds,
+  collectInlineRefs,
+  validateRefs,
   // Low-level helpers for custom renderers (e.g. slide-renderer)
   parseInline,
   renderKatex,

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -16,7 +16,9 @@ const {
   extractDataBlocks,
   KNOWN_SCOPE_TYPES,
   parseInline,
-  renderKatex
+  renderKatex,
+  collectAllIds,
+  validateRefs
 } = require("../src/sdoc.js");
 const fs = require("fs");
 const path = require("path");
@@ -2453,6 +2455,134 @@ test("formatSdoc preserves :comment scope structure", () => {
   assert(lines[3] === "    {");
   assert(lines[4] === "        Agent notes.");
   assert(lines[5] === "    }");
+});
+
+// ============================================================
+console.log("\n--- Reference & Link Validation ---");
+
+test("broken @ref detected", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  See @nonexistent for details.\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const warnings = validateRefs(metaResult.nodes);
+  assert(warnings.length === 1, "expected 1 warning, got " + warnings.length);
+  assert(warnings[0].type === "broken-ref");
+  assert(warnings[0].id === "nonexistent");
+});
+
+test("valid @ref not flagged (explicit @id)", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  # Section @my-section\n  {\n    Content.\n  }\n  See @my-section for details.\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const warnings = validateRefs(metaResult.nodes);
+  assert(warnings.length === 0, "expected 0 warnings, got " + warnings.length);
+});
+
+test("derived slug @ref resolves", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  # My Section\n  {\n    Content.\n  }\n  See @my-section for details.\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const warnings = validateRefs(metaResult.nodes);
+  assert(warnings.length === 0, "expected 0 warnings, got " + warnings.length);
+});
+
+test("absolute URLs skipped", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  Visit [Google](https://google.com) for search.\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const warnings = validateRefs(metaResult.nodes, { resolveFilePath: () => false });
+  assert(warnings.length === 0, "expected 0 warnings for absolute URL, got " + warnings.length);
+});
+
+test("broken relative link detected", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  See [guide](./missing-file.sdoc) for details.\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const warnings = validateRefs(metaResult.nodes, { resolveFilePath: () => false });
+  assert(warnings.length === 1, "expected 1 warning, got " + warnings.length);
+  assert(warnings[0].type === "broken-link");
+  assert(warnings[0].href === "./missing-file.sdoc");
+});
+
+test("valid relative link not flagged", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  See [guide](./existing-file.sdoc) for details.\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const warnings = validateRefs(metaResult.nodes, { resolveFilePath: () => true });
+  assert(warnings.length === 0, "expected 0 warnings, got " + warnings.length);
+});
+
+test("mailto and #anchor links skipped", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  Email [us](mailto:hi@test.com) or jump to [top](#doc).\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const warnings = validateRefs(metaResult.nodes, { resolveFilePath: () => false });
+  assert(warnings.length === 0, "expected 0 warnings for mailto/anchor, got " + warnings.length);
+});
+
+test("broken ref in preview gets sdoc-broken-ref CSS class", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  See @bogus for details.\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const html = renderHtmlDocumentFromParsed(
+    { nodes: metaResult.nodes, errors: parsed.errors },
+    "Test",
+    { renderOptions: { brokenRefIds: new Set(["bogus"]) } }
+  );
+  assert(html.includes("sdoc-broken-ref"), "expected sdoc-broken-ref class in output");
+  assert(html.includes("sdoc-broken-icon"), "expected warning icon in output");
+});
+
+test("broken link in preview gets sdoc-broken-link CSS class", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  See [guide](./missing.sdoc) for details.\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const html = renderHtmlDocumentFromParsed(
+    { nodes: metaResult.nodes, errors: parsed.errors },
+    "Test",
+    { renderOptions: { brokenLinkHrefs: new Set(["./missing.sdoc"]) } }
+  );
+  assert(html.includes("sdoc-broken-link"), "expected sdoc-broken-link class in output");
+  assert(html.includes("sdoc-broken-icon"), "expected warning icon in output");
+});
+
+test("collectAllIds includes explicit IDs and derived slugs", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  # My Section @explicit\n  {\n    Content.\n  }\n  # Another Title\n  {\n    More.\n  }\n}");
+  const ids = collectAllIds(parsed.nodes);
+  assert(ids.has("doc"), "should have 'doc'");
+  assert(ids.has("explicit"), "should have 'explicit'");
+  assert(ids.has("my-section"), "should have derived slug 'my-section'");
+  assert(ids.has("another-title"), "should have derived slug 'another-title'");
+});
+
+test("broken ref inside list item detected", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  {[.]\n    - See @nonexistent for details\n  }\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const warnings = validateRefs(metaResult.nodes);
+  assert(warnings.length === 1, "expected 1 warning for ref in list item, got " + warnings.length);
+  assert(warnings[0].id === "nonexistent");
+});
+
+test("valid ref inside list item not flagged", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  # Setup @setup\n  { Content. }\n  {[.]\n    - See @setup for details\n  }\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const warnings = validateRefs(metaResult.nodes);
+  assert(warnings.length === 0, "expected 0 warnings, got " + warnings.length);
+});
+
+test("collectAllIds finds IDs nested inside list item children", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  {[.]\n    - Item\n    {\n      # Nested @nested-id\n      { Content. }\n    }\n  }\n}");
+  const ids = collectAllIds(parsed.nodes);
+  assert(ids.has("nested-id"), "should have 'nested-id' from inside list item");
+});
+
+test("relative link with fragment does not false-positive", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  See [guide](./exists.sdoc#section) for details.\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const warnings = validateRefs(metaResult.nodes, {
+    resolveFilePath: (p) => p === "./exists.sdoc"
+  });
+  assert(warnings.length === 0, "expected 0 warnings for link with fragment, got " + warnings.length);
+});
+
+test("relative link with query string strips query for resolution", () => {
+  const parsed = parseSdoc("# Doc @doc\n{\n  See [api](./api.sdoc?v=2) for details.\n}");
+  const metaResult = extractMeta(parsed.nodes);
+  const warnings = validateRefs(metaResult.nodes, {
+    resolveFilePath: (p) => p === "./api.sdoc"
+  });
+  assert(warnings.length === 0, "expected 0 warnings for link with query, got " + warnings.length);
 });
 
 // ============================================================

--- a/test/test-broken-refs.sdoc
+++ b/test/test-broken-refs.sdoc
@@ -1,0 +1,71 @@
+# Broken References Test @broken-refs-test
+{
+    # Meta @meta
+    {
+        sdoc-version: 0.2
+    }
+
+    # Valid References
+    {
+        This ref to @setup works (explicit ID).
+        This ref to @valid-references works (derived slug).
+        This ref to @broken-refs-test works (root scope).
+    }
+
+    # Setup @setup
+    {
+        Some setup content here.
+    }
+
+    # Broken References
+    {
+        This ref to @nonexistent-section is broken.
+        This ref to @also-missing is broken too.
+    }
+
+    # Link Tests
+    {
+        This [absolute link](https://example.com) should be fine.
+        This [mailto link](mailto:test@example.com) should be fine.
+        This [anchor link](#setup) should be fine.
+
+        This [broken link](./does-not-exist.sdoc) should warn on save.
+        This [also broken](../nope/missing.txt) should warn on save.
+    }
+
+    # Refs Inside List Items
+    {
+        {[.]
+            - Valid ref in list item: see @setup for details
+            - Broken ref in list item: see @totally-bogus for details
+            - Valid link in list item: [example](https://example.com)
+            - Broken link in list item: [missing](./no-such-file.sdoc)
+        }
+
+        Note: a trailing \`@word\` on a list item line is parsed as the item's scope ID (same as headings), not as an inline reference. Place refs mid-sentence to avoid this.
+    }
+
+    # Nested Scope Inside List Item @nested-test
+    {
+        {[.]
+            - Item with nested scope
+            {
+                # Deeply Nested @deep-id
+                {
+                    A ref to @setup from deep inside a list item (valid).
+
+                    A ref to @phantom from deep inside a list item (broken).
+                }
+            }
+        }
+
+        Ref to @deep-id should work (ID inside list item child).
+    }
+
+    # Links With Fragments
+    {
+        This [link with fragment](./test-broken-refs.sdoc#setup) should be fine on save (file exists, fragment stripped).
+
+        This [broken with fragment](./nope.sdoc#section) should warn on save (file missing).
+    }
+}


### PR DESCRIPTION
## Summary
- Broken `@ref` detection: validates against explicit `@id`s and derived title slugs, shown as editor diagnostics and preview indicators
- Broken relative link detection: checks file existence on save, skips absolute URLs, mailto, anchors, and data URIs
- Strips `#fragment` and `?query` from relative links before file resolution
- Walks list item titles and children for complete validation coverage
- Red wavy underline + warning icon styling with dark mode support

## Test plan
- [x] 15 new unit tests (329 total, all passing)
- [ ] Open `test/test-broken-refs.sdoc` in VS Code — verify broken refs show red in preview and squiggly underlines in editor
- [ ] Save the file — verify broken file links also appear
- [ ] Check dark mode renders broken indicators correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)