### PR TITLE
Broken ref detection and preview stability fix

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -405,11 +405,22 @@ function activate(context) {
 
   context.subscriptions.push(
     vscode.workspace.onDidCloseTextDocument((document) => {
-      const key = document.uri.toString();
-      const panel = panels.get(key);
+      // VS Code fires onDidCloseTextDocument both when a user closes a tab
+      // AND when it silently unloads a document from memory to save resources.
+      // Only dispose the preview if no tab still has the document open.
+      const uriStr = document.uri.toString();
+      const stillOpen = vscode.window.tabGroups.all.some((group) =>
+        group.tabs.some((tab) => {
+          const input = tab.input;
+          return input && input instanceof vscode.TabInputText && input.uri.toString() === uriStr;
+        })
+      );
+      if (stillOpen) return;
+
+      const panel = panels.get(uriStr);
       if (panel) {
         panel.dispose();
-        panels.delete(key);
+        panels.delete(uriStr);
       }
       if (diagnosticCollection && document.languageId === "sdoc") {
         diagnosticCollection.delete(document.uri);


### PR DESCRIPTION
## Summary
- Broken `@ref` detection: validates against explicit `@id`s and derived title slugs, shown as editor diagnostics and preview indicators
- Broken relative link detection: checks file existence on save, skips absolute URLs, mailto, anchors, and data URIs
- Strips `#fragment` and `?query` from relative links before file resolution
- Walks list item titles and children for complete validation coverage
- Red wavy underline + warning icon styling with dark mode support
- Fix preview panel disappearing after idle period (VS Code memory reclamation vs actual tab close)

## Test plan
- [x] 329 unit tests passing
- [ ] Open `test/test-broken-refs.sdoc` — verify broken refs/links show indicators
- [ ] Leave preview open for several minutes — verify it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)