### PR TITLE
Auto-detect email addresses and render as mailto links (v0.2.5)

### DIFF
--- a/examples/example.sdoc
+++ b/examples/example.sdoc
@@ -372,6 +372,8 @@
 
                 Autolinks: https://example.com and mailto:hello@example.com.
 
+                Bare email addresses are auto-linked: hello@example.com.
+
                 Relative file link to another SDOC: [Math Examples](./math-example.sdoc).
 
                 Relative link with section fragment: [Display Math](./math-example.sdoc#display).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sdoc",
   "displayName": "SDOC",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "publisher": "entropicwarrior",
   "license": "MIT",
   "repository": {

--- a/src/sdoc.js
+++ b/src/sdoc.js
@@ -1309,7 +1309,35 @@ function parseInline(text) {
       }
     }
 
-    if (ch === "@" && next && isIdentStart(next)) {
+    // Bare email autolink: local@domain.tld
+    if (ch === "@" && next && /[A-Za-z0-9]/.test(next)) {
+      const prevCh = i > 0 ? text[i - 1] : "";
+      if (/[A-Za-z0-9._+-]/.test(prevCh)) {
+        // Scan forward for domain part (letters, digits, dots, hyphens)
+        let j = i + 1;
+        while (j < text.length && /[A-Za-z0-9.-]/.test(text[j])) j++;
+        // Strip trailing dots/hyphens
+        while (j > i + 1 && /[.-]/.test(text[j - 1])) j--;
+        const domain = text.slice(i + 1, j);
+        // Must have at least one dot with content on both sides
+        if (/^[A-Za-z0-9]([A-Za-z0-9-]*\.)+[A-Za-z]{2,}$/.test(domain)) {
+          // Extract local part from buffer
+          let k = buffer.length;
+          while (k > 0 && /[A-Za-z0-9._+\-]/.test(buffer[k - 1])) k--;
+          const local = buffer.slice(k);
+          if (local.length > 0) {
+            buffer = buffer.slice(0, k);
+            const email = local + "@" + domain;
+            flush();
+            nodes.push({ type: "link", href: "mailto:" + email, children: [{ type: "text", value: email }] });
+            i = j;
+            continue;
+          }
+        }
+      }
+    }
+
+    if (ch === "@" && next && isIdentStart(next) && !(i > 0 && /[A-Za-z0-9._+-]/.test(text[i - 1]))) {
       let j = i + 1;
       while (j < text.length && isIdentChar(text[j])) {
         j += 1;

--- a/syntaxes/sdoc.tmLanguage.json
+++ b/syntaxes/sdoc.tmLanguage.json
@@ -75,6 +75,7 @@
       "patterns": [
         { "include": "#escape" },
         { "include": "#bare-url" },
+        { "include": "#email" },
         { "include": "#reference" },
         { "include": "#inline-code" },
         { "include": "#display-math" },
@@ -102,8 +103,12 @@
       "match": "(?:https?://|mailto:)[^\\s)\\]}>]+",
       "name": "markup.underline.link.sdoc"
     },
+    "email": {
+      "match": "[A-Za-z0-9._+\\-]+@[A-Za-z0-9](?:[A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}",
+      "name": "markup.underline.link.sdoc"
+    },
     "reference": {
-      "match": "(?<!\\\\)@[A-Za-z_][A-Za-z0-9_-]*",
+      "match": "(?<![A-Za-z0-9._+\\-\\\\])@[A-Za-z_][A-Za-z0-9_-]*",
       "name": "entity.name.tag.id.sdoc"
     },
     "inline-code": {


### PR DESCRIPTION
## Summary
- Bare email addresses (e.g. `user@example.com`) are now auto-linked as `mailto:` in the preview
- Email addresses no longer trigger broken-ref errors in editor diagnostics
- TextMate grammar highlights emails as links instead of treating `@domain` as a reference
- Added bare email example to `examples/example.sdoc`

## Test plan
- [x] All 404 tests pass
- [x] Verified `user@example.com`, `support@my-company.org`, `user@example.co.uk` auto-link correctly
- [x] Verified `@reference` syntax still works
- [x] Verified `a@b` (no valid domain) stays as plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)