### PR TITLE
Walk all tagged scopes for section discovery

### DIFF
--- a/src/sdoc.js
+++ b/src/sdoc.js
@@ -2781,8 +2781,31 @@ function firstParagraphPreview(nodes, maxLen) {
   return "";
 }
 
+/**
+ * Recursively collect all tagged (has @id) scope nodes from the content tree.
+ * Skips @meta and @about. Used for deep section discovery — lets MCP clients
+ * find sections nested inside top-level scopes (e.g. @pass-terminology inside
+ * @pedantic-review inside @writing).
+ */
+function getAllTaggedScopes(nodes) {
+  const result = [];
+  function walk(nodeList) {
+    for (const node of nodeList) {
+      if (node.type === "scope") {
+        if (node.id && node.id.toLowerCase() !== "meta" && node.id.toLowerCase() !== "about") {
+          result.push(node);
+        }
+        if (node.children) walk(node.children);
+      }
+    }
+  }
+  const doc = getDocumentScope(nodes);
+  walk(doc ? doc.children : nodes);
+  return result;
+}
+
 function listSections(nodes) {
-  return getContentScopes(nodes).map((node) => ({
+  return getAllTaggedScopes(nodes).map((node) => ({
     id: node.id || null,
     derivedId: slugify(node.title),
     title: node.title,
@@ -2802,7 +2825,7 @@ function collectDataBlocks(children) {
 }
 
 function extractSection(nodes, sectionId) {
-  const scopes = getContentScopes(nodes);
+  const scopes = getAllTaggedScopes(nodes);
 
   function buildResult(node) {
     const data = collectDataBlocks(node.children || []);


### PR DESCRIPTION
## Summary
- `listSections` and `extractSection` now recursively find `@id`-tagged scopes at any nesting depth
- Previously only direct children of the root document scope were visible
- This fixes an issue where MCP clients couldn't discover or load nested sections (e.g. `@pass-terminology` inside `@pedantic-review` inside `@writing`)

## Changes
- New `getAllTaggedScopes()` helper that walks the full scope tree, collecting all tagged scopes (excluding `@meta` and `@about`)
- `listSections` and `extractSection` now use this instead of `getContentScopes` (which only returns direct children)

## Test plan
- [ ] `listSections` on `writing.sdoc` returns the pedantic review passes (`pass-terminology`, `pass-precision`, etc.)
- [ ] `extractSection("pass-terminology")` returns the correct section content
- [ ] Top-level sections still work as before
- [ ] `@meta` and `@about` are still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)