### PR TITLE
Exclude @about scope from rendered output

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sdoc",
   "displayName": "SDOC - Docs for Human/Agent Teams",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "publisher": "entropicwarrior-msenfin",
   "license": "MIT",
   "repository": {

--- a/src/sdoc.js
+++ b/src/sdoc.js
@@ -1495,6 +1495,8 @@ function renderInlineNodes(nodes) {
 function renderScope(scope, depth, isTitleScope = false) {
   // :comment scopes are not rendered
   if (scope.scopeType === "comment") return "";
+  // @about is document metadata, not rendered in output
+  if (scope.id && scope.id.toLowerCase() === "about") return "";
 
   const level = Math.min(6, Math.max(1, depth));
   const children = scope.children.map((child) => renderNode(child, depth + 1)).join("\n");


### PR DESCRIPTION
## Summary
- `@about` is document metadata for agent discovery (`list_knowledge`), not renderable content
- It was incorrectly appearing in VS Code preview, HTML export, and PDF export
- Added a one-line filter in `renderScope` to skip `@about`, matching the existing `:comment` scope pattern
- Bumps version to 0.2.11

## Test plan
- [x] All 445 tests pass
- [x] VS Code preview confirmed — `@about` no longer rendered
- [x] HTML export confirmed in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)