### PR TITLE
Fix Copilot review feedback from PRs #47 and #48

### DIFF
--- a/lexica/specification.sdoc
+++ b/lexica/specification.sdoc
@@ -1146,9 +1146,12 @@ Content of Section A.
                       | "left" | "center" | "right" ;
         percentage    = digit { digit } [ "." digit { digit } ] "%" ;
         pixels        = digit { digit } "px" ;
-        table_body    = [ directive_row ] table_row { table_row } ;
+        table_body    = table_row [ directive_row ] { table_row }
+                      | directive_row { table_row } ;
+                      (* normal tables: header row then optional directive row;
+                         headerless tables: optional directive row first *)
         directive_row = directive_cell { "|" directive_cell } ;
-        directive_cell = [ align_char ] [ ws format_spec ] ;
+        directive_cell = [ align_char ] [ format_spec ] ;
         align_char    = "<" | ">" | "=" ;
         format_spec   = "$" [ "." digits ]
                       | "," [ "." digits ]

--- a/src/sdoc.js
+++ b/src/sdoc.js
@@ -243,7 +243,8 @@ function detectImplicitRoot(cursor) {
     if (nextTrimmed === COMMAND_SCOPE_OPEN ||
         nextTrimmed === COMMAND_LIST_BULLET ||
         nextTrimmed === COMMAND_LIST_NUMBER ||
-        isTableCommand(nextTrimmed)) {
+        isTableCommand(nextTrimmed) ||
+        isCitationsCommand(nextTrimmed)) {
       isImplicit = false;
     } else if (tryParseInlineBlock(nextTrimmed) !== null) {
       isImplicit = false;

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -888,6 +888,13 @@ test("implicit root heading followed by nothing", () => {
   assert(r.nodes[0].children.length === 0);
 });
 
+test("heading followed by {[citations] is explicit, not implicit root", () => {
+  const r = parseSdoc("# Doc\n{[citations]\n    - @a Source A.\n}\n# Other\n{\n    Content.\n}");
+  assert(r.errors.length === 0);
+  // If implicit root were triggered, Other would be nested under Doc
+  assert(r.nodes.length === 2, "expected 2 top-level nodes, got " + r.nodes.length);
+});
+
 // ============================================================
 console.log("\n--- Key:Value Meta Syntax ---");
 


### PR DESCRIPTION
## Summary
- EBNF grammar for `table_body` now accurately reflects that the directive row follows the header row (normal) or appears first (headerless)
- Relaxed `directive_cell` grammar: whitespace between alignment and format is optional, matching the implementation
- Added `{[citations]` to `detectImplicitRoot()` block opener check so it's treated the same as `{[table]`

## Test plan
- [x] 502 tests pass (435 + 24 + 43)
- [x] New test: heading followed by `{[citations]` is not mis-detected as implicit root

🤖 Generated with [Claude Code](https://claude.com/claude-code)