### PR TITLE
feat: render @about as a styled meta-section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 .claude/
 *.log
 *.vsix
+.vscode/settings.json

--- a/docs/reference/api.sdoc
+++ b/docs/reference/api.sdoc
@@ -75,6 +75,7 @@ const html = renderHtmlDocument(sdocText, "Page Title", {
             - `options.config` -- object with `header` and `footer` strings
             - `options.cssOverride` -- replaces the default stylesheet
             - `options.cssAppend` -- appended after the base stylesheet
+            - `options.includeAbout` -- whether to render the `@about` scope (default `false`). Set to `true` for preview-style rendering where the discovery summary should remain visible. See **Hiding @about in exports** below.
             - Automatically extracts and applies `@meta` scope settings
         }
     }
@@ -93,6 +94,33 @@ const html = renderHtmlDocumentFromParsed(
     { meta: metaResult.meta }
 );
         ```
+
+        Accepts the same `options.includeAbout` flag as `renderHtmlDocument` (default `false`).
+    }
+
+    # Hiding `@about` in exports @hiding-about-in-exports
+    {
+        The `@about` scope is a discovery summary — it answers "should I read this document?" for an audience that hasn't decided yet (e.g. an agent doing `list_knowledge`, or a reader browsing a doc index). When a document is exported to HTML or PDF and sent to a specific recipient, that audience has already been told to read it, so the discovery framing adds noise rather than signal.
+
+        For that reason, **all HTML and PDF rendering paths hide `@about` by default**. This applies uniformly to `renderHtmlDocument`, `renderHtmlDocumentFromParsed`, `renderHtmlBody`, the `tools/build-doc.js` CLI, and the VS Code `sdoc.exportHtml` / `sdoc.exportPdf` commands. The live preview in the VS Code extension is the only path that explicitly opts in by passing `includeAbout: true`, so authors still see the meta-section while editing.
+
+        ```javascript
+// Default — @about is hidden (export-shape output)
+const html = renderHtmlDocument(sdocText, "Title");
+const html = renderHtmlDocument(sdocText, "Title", { includeAbout: false });
+
+// Opt in to keep @about (preview-style rendering)
+const html = renderHtmlDocument(sdocText, "Title", { includeAbout: true });
+        ```
+
+        Empty or whitespace-only `@about` scopes are never rendered, regardless of the flag.
+
+        **Helpers.** Two small helpers back this feature, both exported for custom renderers:
+
+        {[.]
+            - `isAboutEmpty(scope)` -- returns `true` when an `@about` scope has no children, or only whitespace-only paragraphs
+            - `stripAboutScopes(nodes)` -- returns a new node array with all `@about` scopes recursively removed; the input is not mutated
+        }
     }
 
     # renderFragment(nodes, depth)

--- a/docs/reference/cli.sdoc
+++ b/docs/reference/cli.sdoc
@@ -29,11 +29,23 @@
         # Export HTML
         {
             Exports the current SDOC document as a self-contained `.html` file. Works from the editor or the preview panel. The exported file includes all styles and supports collapsible scope toggles in the browser.
+
+            **`@about` is hidden by default in exports.** The reasoning: an exported file is normally sent to a specific recipient who has already decided to read it, so the "should I read this?" framing of `@about` is redundant in that context. To keep `@about` in the output, invoke the command programmatically with `{ includeAbout: true }`:
+
+            ```javascript
+vscode.commands.executeCommand("sdoc.exportHtml", { includeAbout: true });
+            ```
         }
 
         # Export PDF
         {
             Exports the current SDOC document as an A4 PDF. Works from the editor or the preview panel. Requires Google Chrome or Chromium installed on the system (or set the `CHROME_PATH` environment variable). The PDF uses print-optimized styles with correct font sizes and preserved marker colors.
+
+            Like Export HTML, `@about` is hidden by default. Pass `{ includeAbout: true }` to keep it:
+
+            ```javascript
+vscode.commands.executeCommand("sdoc.exportPdf", { includeAbout: true });
+            ```
         }
 
         # Open in Browser
@@ -51,6 +63,7 @@ node tools/build-doc.js input.sdoc                   # PDF output (default)
 node tools/build-doc.js input.sdoc -o output.pdf      # PDF with custom path
 node tools/build-doc.js input.sdoc --html             # HTML output
 node tools/build-doc.js input.sdoc --html -o out.html  # HTML with custom path
+node tools/build-doc.js input.sdoc --include-about    # keep @about in the export
         ```
 
         # Options
@@ -58,6 +71,7 @@ node tools/build-doc.js input.sdoc --html -o out.html  # HTML with custom path
             {[.]
                 - `-o <path>` -- output file path (default: input name with `.pdf` or `.html` extension)
                 - `--html` -- export as HTML instead of PDF
+                - `--include-about` -- keep the `@about` scope in the export. By default it is hidden because exported files are normally sent to a specific recipient who has already been asked to read the document, so the discovery summary in `@about` is redundant.
                 - `--help` / `-h` -- show usage information and exit
             }
         }

--- a/docs/reference/sdoc-authoring.sdoc
+++ b/docs/reference/sdoc-authoring.sdoc
@@ -604,7 +604,7 @@ Content of Section B.
 
         # About Scope @about-scope
         {
-            The reserved \`@about\` scope provides a discovery summary for the document. It is used by \`list_knowledge\` to describe the file and is also rendered in the document with a distinct meta-section style so readers can tell it apart from regular body content. Use the bare \`@about\` form (preferred) or the heading form:
+            The reserved \`@about\` scope provides a discovery summary for the document. It is used by \`list_knowledge\` to describe the file and is also rendered in the live preview with a distinct meta-section style so readers can tell it apart from regular body content. Use the bare \`@about\` form (preferred) or the heading form:
 
             ```
             @about {

--- a/docs/reference/sdoc-authoring.sdoc
+++ b/docs/reference/sdoc-authoring.sdoc
@@ -554,7 +554,7 @@ Content of Section B.
         {
             The reserved \`@meta\` scope configures per-file settings and is not rendered in the document body. Use the bare \`@meta\` form (preferred) or the heading form:
 
-            ```
+            ```sdoc
             @meta {
                 type: doc
 
@@ -606,13 +606,18 @@ Content of Section B.
         {
             The reserved \`@about\` scope provides a discovery summary for the document. It is used by \`list_knowledge\` to describe the file and is also rendered in the live preview with a distinct meta-section style so readers can tell it apart from regular body content. Use the bare \`@about\` form (preferred) or the heading form:
 
-            ```
+            ```sdoc
             @about {
-                How to write correct SDOC files. Covers document structure, inline formatting, block types, and common mistakes.
+                How to write correct SDOC files.
+                Covers document structure, inline formatting, block types, and common mistakes.
             }
             ```
 
-            The heading form \`# About @about { }\` also works but the bare form is preferred.
+            The heading form \`# About @about { }\` also works but the bare form is preferred. With the bare form, the renderer synthesizes an \`About\` heading so the meta-section is always labelled. The heading form lets you override that label — \`# Document Discovery @about { }\` renders with `Document Discovery` as the title.
+
+            **Hidden by default in HTML / PDF exports.** Exported files are usually sent to a recipient who has already decided to read the document, so the \`@about\` discovery summary is redundant in that context. To keep it in an export, pass the opt-in flag — \`--include-about\` (see [CLI and Tools Reference](./cli.sdoc)).
+
+            An empty or whitespace-only \`@about\` scope is never rendered, regardless of the include flag.
         }
 
         # Escaping @escaping

--- a/docs/reference/sdoc-authoring.sdoc
+++ b/docs/reference/sdoc-authoring.sdoc
@@ -604,7 +604,7 @@ Content of Section B.
 
         # About Scope @about-scope
         {
-            The reserved \`@about\` scope provides a discovery summary for the document. It is used by \`list_knowledge\` to describe the file but is not rendered in the document body. Use the bare \`@about\` form (preferred) or the heading form:
+            The reserved \`@about\` scope provides a discovery summary for the document. It is used by \`list_knowledge\` to describe the file and is also rendered in the document with a distinct meta-section style so readers can tell it apart from regular body content. Use the bare \`@about\` form (preferred) or the heading form:
 
             ```
             @about {

--- a/lexica/specification.sdoc
+++ b/lexica/specification.sdoc
@@ -982,6 +982,29 @@ Content of Section B.
                 }
             }
         }
+
+        # About Scope @about-scope
+        {
+            A reserved \`@about\` scope holds a short discovery summary for the document — what it covers, who it is for, and when to reach for it. The bare form is preferred:
+
+            ```sdoc
+            @about {
+                How to write correct SDOC files. Covers document structure,
+                inline formatting, block types, and common mistakes.
+            }
+            ```
+
+            The heading form `# Title @about { }` is also accepted; the title given there overrides the default `About` label when the section is rendered.
+
+            {[.]
+                - The `@about` id is reserved and must not be used for normal references
+                - The scope is consumed by discovery tooling (e.g. `list_knowledge` and related agent-facing helpers) to describe a document without loading the full body
+                - In the VS Code live preview, `@about` renders as a meta-section — distinct background, dashed border, subdued typography — so readers can tell it apart from regular body content
+                - **HTML and PDF export hide `@about` by default**, on the principle that an exported file is normally sent to a recipient who has already been asked to read it, so the "should I read this?" framing is redundant. Renderers expose an `includeAbout` opt-in (`--include-about` for the CLI; `{ includeAbout: true }` for the VS Code export commands)
+                - When rendered, a bare `@about { ... }` (no heading line) is given a synthesized `About` heading so the meta-section is always labelled. The heading form preserves any custom title the author wrote
+                - An empty or whitespace-only `@about` scope is never rendered, regardless of the `includeAbout` setting — the meta-section box is suppressed entirely
+            }
+        }
     }
 
     # Interactive Preview @interactive-preview

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sdoc",
   "displayName": "SDOC - Docs for Human/Agent Teams",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "publisher": "entropicwarrior-msenfin",
   "license": "MIT",
   "repository": {

--- a/src/extension.js
+++ b/src/extension.js
@@ -50,12 +50,15 @@ function activate(context) {
     showPreview(document, vscode.ViewColumn.Active);
   });
 
-  const exportHtmlCommand = vscode.commands.registerCommand("sdoc.exportHtml", () => {
-    exportHtml();
+  // Export commands accept an optional { includeAbout } arg when invoked
+  // programmatically (e.g. via `vscode.commands.executeCommand`). Default is
+  // false — the @about scope is hidden in exports.
+  const exportHtmlCommand = vscode.commands.registerCommand("sdoc.exportHtml", (args) => {
+    exportHtml(args || {});
   });
 
-  const exportPdfCommand = vscode.commands.registerCommand("sdoc.exportPdf", () => {
-    exportPdfDoc();
+  const exportPdfCommand = vscode.commands.registerCommand("sdoc.exportPdf", (args) => {
+    exportPdfDoc(args || {});
   });
 
   const openInBrowserCommand = vscode.commands.registerCommand("sdoc.openInBrowser", () => {
@@ -1126,6 +1129,9 @@ async function buildHtml(document, title, webview) {
       cssAppend: cssAppendParts.join("\n"),
       script: buildWebviewScript(),
       mermaidTheme: isDark ? "dark" : "neutral",
+      // Live preview keeps @about visible — the renderer defaults to hiding
+      // it for export-style output.
+      includeAbout: true,
       renderOptions: { editable: false, brokenRefIds, brokenLinkHrefs }
     }
   );
@@ -1356,7 +1362,12 @@ function buildCollapseScript() {
 `;
 }
 
-async function buildCleanHtml(document) {
+// HTML/PDF export path. By default the @about scope is hidden because the
+// recipient of an exported file has already been asked to read it — the
+// "should I read this?" framing in @about is for discovery, not for someone
+// who already has the doc in hand. Pass { includeAbout: true } to keep it.
+async function buildCleanHtml(document, exportOptions = {}) {
+  const includeAbout = exportOptions.includeAbout === true;
   const parsed = parseSdoc(document.getText());
   const metaResult = extractMeta(parsed.nodes);
   const config = loadConfigForDocument(document);
@@ -1393,12 +1404,13 @@ async function buildCleanHtml(document) {
       cssOverride: cssOverride || undefined,
       cssAppend: cssAppendParts.join("\n"),
       script: buildCollapseScript(),
-      mermaidTheme: "auto"
+      mermaidTheme: "auto",
+      includeAbout
     }
   );
 }
 
-async function exportHtml() {
+async function exportHtml(exportOptions = {}) {
   const docPromise = getActivePreviewDocument();
   if (!docPromise) {
     vscode.window.showInformationMessage("No SDOC document is open.");
@@ -1418,12 +1430,12 @@ async function exportHtml() {
     return;
   }
 
-  const html = await buildCleanHtml(document);
+  const html = await buildCleanHtml(document, exportOptions);
   fs.writeFileSync(target.fsPath, html, "utf8");
   vscode.window.showInformationMessage(`Exported: ${path.basename(target.fsPath)}`);
 }
 
-async function exportPdfDoc() {
+async function exportPdfDoc(exportOptions = {}) {
   const docPromise = getActivePreviewDocument();
   if (!docPromise) {
     vscode.window.showInformationMessage("No SDOC document is open.");
@@ -1441,7 +1453,7 @@ async function exportPdfDoc() {
 
   if (!target) return;
 
-  const html = await buildCleanHtml(document);
+  const html = await buildCleanHtml(document, exportOptions);
   const tmpHtml = path.join(os.tmpdir(), "sdoc-pdf-" + Date.now() + ".html");
   fs.writeFileSync(tmpHtml, html, "utf8");
 

--- a/src/notion-renderer.js
+++ b/src/notion-renderer.js
@@ -7,7 +7,7 @@
 //   const { nodes, meta } = extractMeta(parsed.nodes);
 //   const blocks = renderNotionBlocks(nodes);
 
-const { parseInline } = require("./sdoc");
+const { parseInline, isAboutEmpty } = require("./sdoc");
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -294,7 +294,8 @@ function renderScope(scope, depth, nestLevel) {
   if (scope.scopeType === "comment") return [];
 
   if (scope.id && scope.id.toLowerCase() === "about") {
-    return renderAboutCallout(scope);
+    if (isAboutEmpty(scope)) return [];
+    return renderAboutCallout(scope, depth, nestLevel);
   }
 
   const level = Math.min(3, Math.max(1, depth));
@@ -317,7 +318,12 @@ function renderScope(scope, depth, nestLevel) {
 // Render @about as a Notion callout so readers can tell it apart from body
 // content. Paragraph children fold into the callout's rich_text (separated by
 // newlines); anything else becomes a child block.
-function renderAboutCallout(scope) {
+function renderAboutCallout(scope, depth, nestLevel) {
+  // Callout children sit one level deeper in the Notion block tree than the
+  // callout itself. Clamp to MAX_NEST so we never produce blocks past Notion's
+  // nesting limit.
+  const childDepth = depth + 1;
+  const childNestLevel = Math.min(nestLevel + 1, MAX_NEST);
   const richTexts = [];
   const childBlocks = [];
 
@@ -330,7 +336,7 @@ function renderAboutCallout(scope) {
       richTexts.push(...rt);
       childBlocks.push(...imageBlocks);
     } else {
-      childBlocks.push(...renderNode(child, 2, 1));
+      childBlocks.push(...renderNode(child, childDepth, childNestLevel));
     }
   }
 

--- a/src/notion-renderer.js
+++ b/src/notion-renderer.js
@@ -293,6 +293,10 @@ function renderNode(node, depth, nestLevel) {
 function renderScope(scope, depth, nestLevel) {
   if (scope.scopeType === "comment") return [];
 
+  if (scope.id && scope.id.toLowerCase() === "about") {
+    return renderAboutCallout(scope);
+  }
+
   const level = Math.min(3, Math.max(1, depth));
 
   if (scope.hasHeading === false) {
@@ -308,6 +312,44 @@ function renderScope(scope, depth, nestLevel) {
   // At the nest limit: emit flat heading, children as siblings at same level
   const childBlocks = renderChildren(scope.children, depth + 1, nestLevel);
   return [headingBlock(level, scope.title, null), ...childBlocks];
+}
+
+// Render @about as a Notion callout so readers can tell it apart from body
+// content. Paragraph children fold into the callout's rich_text (separated by
+// newlines); anything else becomes a child block.
+function renderAboutCallout(scope) {
+  const richTexts = [];
+  const childBlocks = [];
+
+  for (const child of scope.children || []) {
+    if (child.type === "paragraph") {
+      if (richTexts.length > 0) {
+        richTexts.push(richText("\n", null, defaultAnnotations()));
+      }
+      const { richText: rt, imageBlocks } = extractImagesFromInline(child.text);
+      richTexts.push(...rt);
+      childBlocks.push(...imageBlocks);
+    } else {
+      childBlocks.push(...renderNode(child, 2, 1));
+    }
+  }
+
+  if (richTexts.length === 0) {
+    richTexts.push(richText("", null, defaultAnnotations()));
+  }
+
+  const callout = {
+    type: "callout",
+    callout: {
+      rich_text: enforceContentLimit(richTexts, RICH_TEXT_LIMIT),
+      icon: { type: "emoji", emoji: "ℹ️" },
+      color: "gray_background"
+    }
+  };
+  if (childBlocks.length > 0) {
+    callout.callout.children = childBlocks;
+  }
+  return [callout];
 }
 
 function renderParagraph(node) {

--- a/src/sdoc.js
+++ b/src/sdoc.js
@@ -1827,7 +1827,7 @@ function renderScope(scope, depth, isTitleScope = false) {
   const dl = dataLineAttrs(scope);
   const typeAttr = scope.scopeType ? ` data-scope-type="${escapeAttr(scope.scopeType)}"` : "";
   const typeClass = scope.scopeType ? ` sdoc-scope-type-${scope.scopeType}` : "";
-  const metaClass = isAbout ? " sdoc-meta-section sdoc-meta-section-about" : "";
+  const metaClass = isAbout ? " sdoc-meta-section" : "";
 
   if (scope.hasHeading === false) {
     return `<section class="sdoc-scope sdoc-scope-noheading${rootClass}${typeClass}${metaClass}"${typeAttr}${dl}>${children}</section>`;
@@ -2946,7 +2946,7 @@ const DEFAULT_STYLE = `
      so readers can tell at a glance this is document metadata, not body content. */
   .sdoc-scope.sdoc-meta-section {
     position: relative;
-    margin: 1.2rem 0 1.6rem 3rem;
+    margin: 1.2rem 3rem 1.6rem 3rem;
     padding: 0.7rem 1rem 0.7rem 1rem;
     background: rgba(127, 120, 112, 0.06);
     border: 1px dashed var(--sdoc-border);

--- a/src/sdoc.js
+++ b/src/sdoc.js
@@ -1823,6 +1823,13 @@ function renderScope(scope, depth, isTitleScope = false) {
   // Skip empty/whitespace-only @about — no point rendering an empty meta box.
   if (isAbout && isAboutEmpty(scope)) return "";
 
+  // Bare `@about { ... }` (no heading) and heading-form with empty title both
+  // get a default heading of "About" so the meta-section is always labelled.
+  // A custom title (e.g. `# Document Discovery @about`) is preserved.
+  if (isAbout && (!scope.hasHeading || !scope.title || !scope.title.trim())) {
+    scope = { ...scope, hasHeading: true, title: "About" };
+  }
+
   const level = Math.min(6, Math.max(1, depth));
   const children = scope.children.map((child) => renderNode(child, depth + 1)).join("\n");
   const rootClass = isTitleScope ? " sdoc-root" : "";
@@ -3118,15 +3125,21 @@ function renderBodyNodes(nodes) {
     .join("\n");
 }
 
-function renderHtmlBody(text) {
+function renderHtmlBody(text, options = {}) {
   const parsed = parseSdoc(text);
   const metaResult = extractMeta(parsed.nodes);
   const savedOptions = _renderOptions;
   _renderOptions = {};
-  const citationData = buildCitationNumbering(metaResult.nodes);
+  // includeAbout defaults to false: HTML output is treated as "export-shape"
+  // by default, hiding the discovery summary. The preview path in
+  // extension.js opts in with `includeAbout: true` to keep the meta-section
+  // visible during authoring.
+  const includeAbout = options.includeAbout === true;
+  const renderNodes = includeAbout ? metaResult.nodes : stripAboutScopes(metaResult.nodes);
+  const citationData = buildCitationNumbering(renderNodes);
   _citationNumbering = citationData.numbering;
   _citationDefinitions = citationData.definitions;
-  const result = renderBodyNodes(metaResult.nodes);
+  const result = renderBodyNodes(renderNodes);
   _citationNumbering = new Map();
   _citationDefinitions = new Map();
   _renderOptions = savedOptions;
@@ -3135,10 +3148,16 @@ function renderHtmlBody(text) {
 
 function renderHtmlDocumentFromParsed(parsed, title, options = {}) {
   _renderOptions = options.renderOptions ?? {};
-  const citationData = buildCitationNumbering(parsed.nodes);
+  // includeAbout defaults to false: HTML/PDF output is hidden-by-default
+  // because exported files are normally sent to a specific recipient who has
+  // already been asked to read the doc, so the "should I read this?" framing
+  // in @about adds noise. The live preview opts in with `includeAbout: true`.
+  const includeAbout = options.includeAbout === true;
+  const renderNodes = includeAbout ? parsed.nodes : stripAboutScopes(parsed.nodes);
+  const citationData = buildCitationNumbering(renderNodes);
   _citationNumbering = citationData.numbering;
   _citationDefinitions = citationData.definitions;
-  const body = renderBodyNodes(parsed.nodes);
+  const body = renderBodyNodes(renderNodes);
   _citationNumbering = new Map();
   _citationDefinitions = new Map();
   _renderOptions = {};
@@ -3166,13 +3185,13 @@ function renderHtmlDocumentFromParsed(parsed, title, options = {}) {
   const mermaidInit = mermaidTheme === "auto"
     ? `var isDark=window.matchMedia("(prefers-color-scheme:dark)").matches;mermaid.initialize({startOnLoad:true,theme:isDark?"dark":"neutral",themeCSS:".node rect, .node polygon, .node circle { rx: 4; ry: 4; }"});`
     : `mermaid.initialize({startOnLoad:true,theme:"${mermaidTheme}",themeCSS:".node rect, .node polygon, .node circle { rx: 4; ry: 4; }"});`;
-  const mermaidScript = hasMermaidBlocks(parsed.nodes)
+  const mermaidScript = hasMermaidBlocks(renderNodes)
     ? `\n<script src="${MERMAID_CDN}"></script>\n<script>${mermaidInit}</script>`
     : "";
   const katexCssTag = body.includes('class="katex"')
     ? `\n<link rel="stylesheet" href="${KATEX_CDN_CSS}" />`
     : "";
-  const hasHljs = hasHighlightableCodeBlocks(parsed.nodes);
+  const hasHljs = hasHighlightableCodeBlocks(renderNodes);
   // Highlight.js CSS is inlined (not a <link>) so it is extracted by parseDocHtml in the web viewer
   // and applied inside shadow DOM. The @media query handles dark mode in browsers.
   const hljsCssInline = hasHljs
@@ -3494,6 +3513,26 @@ function isAboutEmpty(scope) {
   );
 }
 
+// Recursively remove @about scopes from an AST. Used by the HTML/PDF export
+// paths, which hide @about by default: when a doc is exported and sent to a
+// specific recipient, the "should I read this?" framing is moot — the sender
+// already decided the answer is yes. Pass-through for nodes without children.
+function stripAboutScopes(nodes) {
+  if (!Array.isArray(nodes)) return nodes;
+  const result = [];
+  for (const node of nodes) {
+    if (node && node.type === "scope" && node.id && node.id.toLowerCase() === "about") {
+      continue;
+    }
+    if (node && node.type === "scope" && Array.isArray(node.children)) {
+      result.push({ ...node, children: stripAboutScopes(node.children) });
+    } else {
+      result.push(node);
+    }
+  }
+  return result;
+}
+
 function collectAllIds(nodes) {
   const ids = new Set();
   function walk(nodeList) {
@@ -3720,6 +3759,7 @@ module.exports = {
   extractSection,
   extractAbout,
   isAboutEmpty,
+  stripAboutScopes,
   extractDataBlocks,
   KNOWN_SCOPE_TYPES,
   // Validation

--- a/src/sdoc.js
+++ b/src/sdoc.js
@@ -1818,8 +1818,8 @@ function renderInlineNodes(nodes) {
 function renderScope(scope, depth, isTitleScope = false) {
   // :comment scopes are not rendered
   if (scope.scopeType === "comment") return "";
-  // @about is document metadata, not rendered in output
-  if (scope.id && scope.id.toLowerCase() === "about") return "";
+
+  const isAbout = scope.id && scope.id.toLowerCase() === "about";
 
   const level = Math.min(6, Math.max(1, depth));
   const children = scope.children.map((child) => renderNode(child, depth + 1)).join("\n");
@@ -1827,9 +1827,10 @@ function renderScope(scope, depth, isTitleScope = false) {
   const dl = dataLineAttrs(scope);
   const typeAttr = scope.scopeType ? ` data-scope-type="${escapeAttr(scope.scopeType)}"` : "";
   const typeClass = scope.scopeType ? ` sdoc-scope-type-${scope.scopeType}` : "";
+  const metaClass = isAbout ? " sdoc-meta-section sdoc-meta-section-about" : "";
 
   if (scope.hasHeading === false) {
-    return `<section class="sdoc-scope sdoc-scope-noheading${rootClass}${typeClass}"${typeAttr}${dl}>${children}</section>`;
+    return `<section class="sdoc-scope sdoc-scope-noheading${rootClass}${typeClass}${metaClass}"${typeAttr}${dl}>${children}</section>`;
   }
 
   const idAttr = scope.id ? ` id="${escapeAttr(scope.id)}"` : "";
@@ -1837,7 +1838,7 @@ function renderScope(scope, depth, isTitleScope = false) {
   const toggle = hasChildren ? `<span class="sdoc-toggle"></span>` : "";
   const heading = `<h${level}${idAttr} class="sdoc-heading sdoc-depth-${level}"${dl}>${toggle}${renderInline(scope.title)}</h${level}>`;
   const childrenHtml = children ? `\n<div class="sdoc-scope-children">${children}</div>` : "";
-  return `<section class="sdoc-scope${rootClass}${typeClass}"${typeAttr}>${heading}${childrenHtml}</section>`;
+  return `<section class="sdoc-scope${rootClass}${typeClass}${metaClass}"${typeAttr}>${heading}${childrenHtml}</section>`;
 }
 
 function renderCitations(node) {
@@ -2939,6 +2940,43 @@ const DEFAULT_STYLE = `
 
   .sdoc-scope.sdoc-collapsed > .sdoc-scope-children {
     display: none;
+  }
+
+  /* Meta sections (@about) — rendered with a distinct, subdued style
+     so readers can tell at a glance this is document metadata, not body content. */
+  .sdoc-scope.sdoc-meta-section {
+    position: relative;
+    margin: 1.2rem 0 1.6rem 3rem;
+    padding: 0.7rem 1rem 0.7rem 1rem;
+    background: rgba(127, 120, 112, 0.06);
+    border: 1px dashed var(--sdoc-border);
+    border-left: 3px solid var(--sdoc-muted);
+    border-radius: 6px;
+    color: var(--sdoc-muted);
+    font-size: 0.95em;
+  }
+
+  .sdoc-meta-section .sdoc-heading {
+    margin-top: 0.2rem;
+    color: var(--sdoc-muted);
+    font-weight: 600;
+    border-bottom: none;
+  }
+
+  .sdoc-meta-section .sdoc-paragraph {
+    margin: 0.3rem 0;
+    font-style: italic;
+  }
+
+  .sdoc-meta-section .sdoc-scope-children > .sdoc-scope {
+    padding-left: 0;
+  }
+
+  /* Place the collapse toggle in the gutter to the LEFT of the meta
+     box (in the space created by margin-left), not on the colored
+     left border. Default is left: -1.4em which lands on the border. */
+  .sdoc-meta-section > .sdoc-heading > .sdoc-toggle {
+    left: -2.6em;
   }
 
 `;

--- a/src/sdoc.js
+++ b/src/sdoc.js
@@ -1820,6 +1820,8 @@ function renderScope(scope, depth, isTitleScope = false) {
   if (scope.scopeType === "comment") return "";
 
   const isAbout = scope.id && scope.id.toLowerCase() === "about";
+  // Skip empty/whitespace-only @about — no point rendering an empty meta box.
+  if (isAbout && isAboutEmpty(scope)) return "";
 
   const level = Math.min(6, Math.max(1, depth));
   const children = scope.children.map((child) => renderNode(child, depth + 1)).join("\n");
@@ -3482,6 +3484,16 @@ function extractAbout(nodes) {
   return null;
 }
 
+// True when an @about scope has no meaningful content. Renderers use this to
+// skip emitting an empty meta-section / callout. Whitespace-only paragraphs
+// count as empty.
+function isAboutEmpty(scope) {
+  if (!scope || !scope.children || scope.children.length === 0) return true;
+  return scope.children.every(
+    (child) => child.type === "paragraph" && (!child.text || child.text.trim() === "")
+  );
+}
+
 function collectAllIds(nodes) {
   const ids = new Set();
   function walk(nodeList) {
@@ -3707,6 +3719,7 @@ module.exports = {
   listSections,
   extractSection,
   extractAbout,
+  isAboutEmpty,
   extractDataBlocks,
   KNOWN_SCOPE_TYPES,
   // Validation

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -13,6 +13,7 @@ const {
   listSections,
   extractSection,
   extractAbout,
+  isAboutEmpty,
   extractDataBlocks,
   KNOWN_SCOPE_TYPES,
   parseInline,
@@ -608,6 +609,82 @@ test("task list renders checkboxes", () => {
 test("scope heading toggle is present", () => {
   const html = renderHtmlDocument("# Doc\n{\n  # Child\n  {\n    Nested.\n  }\n}", "Test");
   assert(html.includes("sdoc-toggle"));
+});
+
+// ============================================================
+console.log("\n--- @about HTML rendering ---");
+
+test("bare @about renders with sdoc-meta-section class and content", () => {
+  const html = renderHtmlDocument("# Doc\n{\n  @about\n  {\n    A short summary.\n  }\n  # Body\n  {\n    Content.\n  }\n}", "Test");
+  assert(html.includes("sdoc-meta-section"), "should include sdoc-meta-section class");
+  assert(html.includes("A short summary."), "about content should be rendered, not filtered");
+  assert(html.includes("sdoc-scope-noheading"), "bare @about should render as headingless scope");
+});
+
+test("heading-form @about renders with sdoc-meta-section class and content", () => {
+  const html = renderHtmlDocument("# Doc\n{\n  # About @about\n  {\n    Description here.\n  }\n  # Body\n  {\n    Content.\n  }\n}", "Test");
+  assert(html.includes("sdoc-meta-section"), "should include sdoc-meta-section class");
+  assert(html.includes("Description here."), "about content should be rendered, not filtered");
+  assert(/<h\d[^>]*>(?:<span class="sdoc-toggle"[^>]*><\/span>)?About<\/h\d>/.test(html), "About heading should be emitted");
+});
+
+test("@About heading-form with mixed-case id still gets meta-section class", () => {
+  const html = renderHtmlDocument("# Doc\n{\n  # About @About\n  {\n    Mixed case id.\n  }\n}", "Test");
+  assert(html.includes("sdoc-meta-section"), "case-insensitive @About should get meta-section class");
+  assert(html.includes("Mixed case id."));
+});
+
+test("empty bare @about renders nothing (no meta-section)", () => {
+  const html = renderHtmlBody("# Doc\n{\n  @about\n  {\n  }\n  # Body\n  {\n    Content.\n  }\n}");
+  assert(!html.includes("sdoc-meta-section"), "empty @about should not emit meta-section wrapper");
+  assert(html.includes("Body"), "rest of document should still render");
+});
+
+test("empty heading-form @about renders nothing", () => {
+  const html = renderHtmlBody("# Doc\n{\n  # About @about\n  {\n  }\n  # Body\n  {\n    Content.\n  }\n}");
+  assert(!html.includes("sdoc-meta-section"), "empty @about should not emit meta-section wrapper");
+  assert(!/<h\d[^>]*>(?:<span class="sdoc-toggle"[^>]*><\/span>)?About<\/h\d>/.test(html), "About heading should not be emitted for empty scope");
+  assert(html.includes("Body"));
+});
+
+test("whitespace-only @about renders nothing", () => {
+  const html = renderHtmlBody("# Doc\n{\n  @about\n  {\n     \n  \t  \n  }\n  # Body\n  {\n    Content.\n  }\n}");
+  assert(!html.includes("sdoc-meta-section"), "whitespace-only @about should be treated as empty");
+  assert(html.includes("Body"));
+});
+
+test("@about with non-blank content still renders meta-section", () => {
+  const html = renderHtmlBody("# Doc\n{\n  @about\n  {\n    Has content.\n  }\n  # Body\n  {\n    More.\n  }\n}");
+  assert(html.includes("sdoc-meta-section"));
+  assert(html.includes("Has content."));
+});
+
+test("isAboutEmpty: no children → empty", () => {
+  assert(isAboutEmpty({ children: [] }) === true);
+});
+
+test("isAboutEmpty: missing children → empty", () => {
+  assert(isAboutEmpty({}) === true);
+  assert(isAboutEmpty(null) === true);
+});
+
+test("isAboutEmpty: paragraph with content → not empty", () => {
+  assert(isAboutEmpty({ children: [{ type: "paragraph", text: "Hi." }] }) === false);
+});
+
+test("isAboutEmpty: whitespace-only paragraph → empty", () => {
+  assert(isAboutEmpty({ children: [{ type: "paragraph", text: "   \t  " }] }) === true);
+});
+
+test("isAboutEmpty: mix of whitespace paragraphs → empty", () => {
+  assert(isAboutEmpty({ children: [
+    { type: "paragraph", text: " " },
+    { type: "paragraph", text: "" }
+  ] }) === true);
+});
+
+test("isAboutEmpty: non-paragraph child (list) → not empty", () => {
+  assert(isAboutEmpty({ children: [{ type: "list", items: [] }] }) === false);
 });
 
 // ============================================================

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -14,6 +14,7 @@ const {
   extractSection,
   extractAbout,
   isAboutEmpty,
+  stripAboutScopes,
   extractDataBlocks,
   KNOWN_SCOPE_TYPES,
   parseInline,
@@ -614,24 +615,53 @@ test("scope heading toggle is present", () => {
 // ============================================================
 console.log("\n--- @about HTML rendering ---");
 
-test("bare @about renders with sdoc-meta-section class and content", () => {
-  const html = renderHtmlDocument("# Doc\n{\n  @about\n  {\n    A short summary.\n  }\n  # Body\n  {\n    Content.\n  }\n}", "Test");
+test("bare @about renders with sdoc-meta-section class and content (preview-style)", () => {
+  // Renderer hides @about by default, so opt in to verify the meta-section emission.
+  const html = renderHtmlDocument("# Doc\n{\n  @about\n  {\n    A short summary.\n  }\n  # Body\n  {\n    Content.\n  }\n}", "Test", { includeAbout: true });
   assert(html.includes("sdoc-meta-section"), "should include sdoc-meta-section class");
-  assert(html.includes("A short summary."), "about content should be rendered, not filtered");
-  assert(html.includes("sdoc-scope-noheading"), "bare @about should render as headingless scope");
+  assert(html.includes("A short summary."), "about content should be rendered when includeAbout: true");
+  // Bare @about now gets a synthetic "About" heading instead of rendering headingless.
+  // Check the element itself, not just the class string (which also appears in inlined CSS).
+  assert(!/<section [^>]*sdoc-scope-noheading[^>]*>/.test(html), "bare @about should no longer render as a noheading section");
 });
 
-test("heading-form @about renders with sdoc-meta-section class and content", () => {
-  const html = renderHtmlDocument("# Doc\n{\n  # About @about\n  {\n    Description here.\n  }\n  # Body\n  {\n    Content.\n  }\n}", "Test");
+test("heading-form @about renders with sdoc-meta-section class and content (preview-style)", () => {
+  const html = renderHtmlDocument("# Doc\n{\n  # About @about\n  {\n    Description here.\n  }\n  # Body\n  {\n    Content.\n  }\n}", "Test", { includeAbout: true });
   assert(html.includes("sdoc-meta-section"), "should include sdoc-meta-section class");
-  assert(html.includes("Description here."), "about content should be rendered, not filtered");
+  assert(html.includes("Description here."), "about content should be rendered when includeAbout: true");
   assert(/<h\d[^>]*>(?:<span class="sdoc-toggle"[^>]*><\/span>)?About<\/h\d>/.test(html), "About heading should be emitted");
 });
 
-test("@About heading-form with mixed-case id still gets meta-section class", () => {
-  const html = renderHtmlDocument("# Doc\n{\n  # About @About\n  {\n    Mixed case id.\n  }\n}", "Test");
+test("@About heading-form with mixed-case id still gets meta-section class (preview-style)", () => {
+  const html = renderHtmlDocument("# Doc\n{\n  # About @About\n  {\n    Mixed case id.\n  }\n}", "Test", { includeAbout: true });
   assert(html.includes("sdoc-meta-section"), "case-insensitive @About should get meta-section class");
   assert(html.includes("Mixed case id."));
+});
+
+// --- @about default heading title ---
+
+const ABOUT_TITLE_HEADING = /<h\d[^>]*\bid="about"[^>]*>(?:<span class="sdoc-toggle"[^>]*><\/span>)?([^<]+)<\/h\d>/;
+
+test("@about with no title defaults to \"About\" heading", () => {
+  const html = renderHtmlDocument("# Doc\n{\n  @about\n  {\n    Summary.\n  }\n}", "Test", { includeAbout: true });
+  const m = html.match(ABOUT_TITLE_HEADING);
+  assert(m, "@about should produce a heading element with id=\"about\"");
+  assert(m[1] === "About", "default title should be \"About\", got: " + m[1]);
+  assert(html.includes("Summary."), "content should still render");
+});
+
+test("@about with explicit \"About\" title renders \"About\" heading", () => {
+  const html = renderHtmlDocument("# Doc\n{\n  # About @about\n  {\n    Summary.\n  }\n}", "Test", { includeAbout: true });
+  const m = html.match(ABOUT_TITLE_HEADING);
+  assert(m, "@about should produce a heading element with id=\"about\"");
+  assert(m[1] === "About", "explicit title should render as \"About\", got: " + m[1]);
+});
+
+test("@about with custom title preserves the custom title", () => {
+  const html = renderHtmlDocument("# Doc\n{\n  # Document Discovery @about\n  {\n    Summary.\n  }\n}", "Test", { includeAbout: true });
+  const m = html.match(ABOUT_TITLE_HEADING);
+  assert(m, "@about should produce a heading element with id=\"about\"");
+  assert(m[1] === "Document Discovery", "custom title should NOT be replaced with default, got: " + m[1]);
 });
 
 test("empty bare @about renders nothing (no meta-section)", () => {
@@ -653,8 +683,8 @@ test("whitespace-only @about renders nothing", () => {
   assert(html.includes("Body"));
 });
 
-test("@about with non-blank content still renders meta-section", () => {
-  const html = renderHtmlBody("# Doc\n{\n  @about\n  {\n    Has content.\n  }\n  # Body\n  {\n    More.\n  }\n}");
+test("@about with non-blank content renders meta-section when includeAbout: true", () => {
+  const html = renderHtmlBody("# Doc\n{\n  @about\n  {\n    Has content.\n  }\n  # Body\n  {\n    More.\n  }\n}", { includeAbout: true });
   assert(html.includes("sdoc-meta-section"));
   assert(html.includes("Has content."));
 });
@@ -685,6 +715,86 @@ test("isAboutEmpty: mix of whitespace paragraphs → empty", () => {
 
 test("isAboutEmpty: non-paragraph child (list) → not empty", () => {
   assert(isAboutEmpty({ children: [{ type: "list", items: [] }] }) === false);
+});
+
+// ============================================================
+console.log("\n--- includeAbout option (export hides @about) ---");
+
+const ABOUT_SRC = "# Doc\n{\n  @about\n  {\n    Discovery summary text.\n  }\n  # Body\n  {\n    Real content.\n  }\n}";
+
+function hasAboutElement(html) {
+  // Match the actual <section> element — the class string also appears in the
+  // inlined CSS, so a substring check would give false positives.
+  return /<section [^>]*sdoc-meta-section[^>]*>/.test(html);
+}
+
+test("renderHtmlDocument default hides @about (export-shape output)", () => {
+  const html = renderHtmlDocument(ABOUT_SRC, "Test");
+  assert(!hasAboutElement(html), "default should NOT render the meta-section element");
+  assert(!html.includes("Discovery summary text."), "@about content should be stripped by default");
+  assert(html.includes("Real content."), "rest of the document still renders");
+});
+
+test("renderHtmlDocument with explicit includeAbout: false matches default", () => {
+  const html = renderHtmlDocument(ABOUT_SRC, "Test", { includeAbout: false });
+  assert(!hasAboutElement(html), "no meta-section element should be emitted");
+  assert(!html.includes("Discovery summary text."));
+  assert(html.includes("Real content."));
+});
+
+test("renderHtmlDocument with includeAbout: true keeps @about (preview path)", () => {
+  const html = renderHtmlDocument(ABOUT_SRC, "Test", { includeAbout: true });
+  assert(hasAboutElement(html));
+  assert(html.includes("Discovery summary text."));
+});
+
+test("renderHtmlBody respects includeAbout option", () => {
+  const bodyDefault = renderHtmlBody(ABOUT_SRC);
+  const bodyOptIn = renderHtmlBody(ABOUT_SRC, { includeAbout: true });
+  assert(!bodyDefault.includes("sdoc-meta-section"), "default hides about");
+  assert(bodyOptIn.includes("sdoc-meta-section"), "opt-in keeps about");
+  assert(bodyDefault.includes("Real content."), "rest of doc still renders even when about is hidden");
+});
+
+test("stripAboutScopes removes top-level @about", () => {
+  const r = parseSdoc(ABOUT_SRC);
+  const stripped = stripAboutScopes(r.nodes);
+  function hasAbout(nodes) {
+    return nodes.some((n) =>
+      (n.type === "scope" && n.id && n.id.toLowerCase() === "about")
+      || (n.children && hasAbout(n.children))
+    );
+  }
+  assert(!hasAbout(stripped), "no @about scope should remain after stripping");
+});
+
+test("stripAboutScopes is recursive (removes nested @about too)", () => {
+  const r = parseSdoc("# Doc\n{\n  @about\n  {\n    Top.\n  }\n  # Inner\n  {\n    # About @about\n    {\n      Nested.\n    }\n    Body.\n  }\n}");
+  const stripped = stripAboutScopes(r.nodes);
+  function findAboutDeep(nodes) {
+    return nodes.some((n) =>
+      (n.type === "scope" && n.id && n.id.toLowerCase() === "about")
+      || (n.children && findAboutDeep(n.children))
+    );
+  }
+  assert(!findAboutDeep(stripped), "nested @about should also be removed");
+});
+
+test("stripAboutScopes preserves non-about siblings unchanged", () => {
+  const r = parseSdoc(ABOUT_SRC);
+  const stripped = stripAboutScopes(r.nodes);
+  // Top-level Doc scope should still have its non-about child (Body).
+  const doc = stripped.find((n) => n.type === "scope" && n.title === "Doc");
+  assert(doc, "Doc scope should still be present");
+  const body = doc.children.find((n) => n.type === "scope" && n.title === "Body");
+  assert(body, "Body scope should still be present after stripping @about");
+});
+
+test("stripAboutScopes does not mutate input nodes", () => {
+  const r = parseSdoc(ABOUT_SRC);
+  const before = JSON.stringify(r.nodes);
+  stripAboutScopes(r.nodes);
+  assert(JSON.stringify(r.nodes) === before, "input AST should be unchanged");
 });
 
 // ============================================================

--- a/test/test-notion.js
+++ b/test/test-notion.js
@@ -518,5 +518,102 @@ test("deeply nested scopes all flatten under heading_1", () => {
 });
 
 // ============================================================
+console.log("\n--- @about callout rendering ---");
+
+test("bare @about renders as a callout block", () => {
+  const sdoc = "# Doc {\n  @about {\n    A short summary.\n  }\n  # Body {\n    Content.\n  }\n}";
+  const blocks = parseAndRender(sdoc);
+  const docChildren = blocks[0].heading_1.children;
+  const callout = docChildren.find(b => b.type === "callout");
+  assert(callout, "should produce a callout block for @about");
+  assert(callout.callout.icon.emoji === "ℹ️", "callout uses info icon");
+  assert(callout.callout.color === "gray_background", "callout uses gray background");
+  const text = callout.callout.rich_text.map(rt => rt.text.content).join("");
+  assert(text.includes("A short summary."), "callout rich_text should include the about prose");
+});
+
+test("heading-form @about renders as callout without an extra heading block", () => {
+  const sdoc = "# Doc {\n  # About @about {\n    Description here.\n  }\n  # Body {\n    Body content.\n  }\n}";
+  const blocks = parseAndRender(sdoc);
+  const docChildren = blocks[0].heading_1.children;
+  const aboutBlocks = docChildren.filter(b => b.type === "callout" || (b.type === "heading_2" && b.heading_2.rich_text.some(rt => rt.text.content === "About")));
+  assert(aboutBlocks.length === 1, "should not emit an extra About heading; got " + aboutBlocks.length);
+  assert(aboutBlocks[0].type === "callout", "About scope should render as callout, not a heading");
+  const text = aboutBlocks[0].callout.rich_text.map(rt => rt.text.content).join("");
+  assert(text.includes("Description here."));
+});
+
+test("@about with multiple paragraphs joins them with newlines in callout rich_text", () => {
+  const sdoc = "# Doc {\n  @about {\n    First paragraph.\n\n    Second paragraph.\n  }\n}";
+  const blocks = parseAndRender(sdoc);
+  const callout = blocks[0].heading_1.children.find(b => b.type === "callout");
+  assert(callout, "should produce a callout");
+  const text = callout.callout.rich_text.map(rt => rt.text.content).join("");
+  assert(text.includes("First paragraph."));
+  assert(text.includes("Second paragraph."));
+  assert(text.includes("\n"), "paragraphs should be separated by a newline");
+});
+
+test("@about with a list emits the list as a callout child", () => {
+  const sdoc = "# Doc {\n  @about {\n    Intro line.\n    {[.]\n      - First\n      - Second\n    }\n  }\n}";
+  const blocks = parseAndRender(sdoc);
+  const callout = blocks[0].heading_1.children.find(b => b.type === "callout");
+  assert(callout, "should produce a callout");
+  assert(Array.isArray(callout.callout.children), "callout should have children array when list is present");
+  const listBlocks = callout.callout.children.filter(b => b.type === "bulleted_list_item");
+  assert(listBlocks.length === 2, "list items should be rendered as callout children, got " + listBlocks.length);
+});
+
+test("@about with a table emits the table as a callout child", () => {
+  const sdoc = "# Doc {\n  @about {\n    Summary.\n    {[table]\n      Key | Value\n      a | 1\n    }\n  }\n}";
+  const blocks = parseAndRender(sdoc);
+  const callout = blocks[0].heading_1.children.find(b => b.type === "callout");
+  assert(callout, "should produce a callout");
+  assert(Array.isArray(callout.callout.children), "callout should have children array when table is present");
+  const tableBlock = callout.callout.children.find(b => b.type === "table");
+  assert(tableBlock, "table should be rendered as a callout child");
+});
+
+test("@About heading-form with mixed-case id still renders as callout", () => {
+  const sdoc = "# Doc {\n  # About @About {\n    Case insensitive.\n  }\n}";
+  const blocks = parseAndRender(sdoc);
+  const callout = blocks[0].heading_1.children.find(b => b.type === "callout");
+  assert(callout, "case-insensitive @About should still render as callout");
+});
+
+test("empty bare @about emits no callout", () => {
+  const sdoc = "# Doc {\n  @about {\n  }\n  # Body {\n    Content.\n  }\n}";
+  const blocks = parseAndRender(sdoc);
+  const docChildren = blocks[0].heading_1.children;
+  assert(!docChildren.some(b => b.type === "callout"), "empty @about should not emit a callout block");
+  assert(docChildren.some(b => b.type === "heading_2"), "rest of document should still render");
+});
+
+test("empty heading-form @about emits no callout and no heading", () => {
+  const sdoc = "# Doc {\n  # About @about {\n  }\n  # Body {\n    Content.\n  }\n}";
+  const blocks = parseAndRender(sdoc);
+  const docChildren = blocks[0].heading_1.children;
+  assert(!docChildren.some(b => b.type === "callout"), "empty @about should not emit a callout");
+  const aboutHeading = docChildren.find(b =>
+    b.type === "heading_2" && b.heading_2.rich_text.some(rt => rt.text.content === "About")
+  );
+  assert(!aboutHeading, "empty @about should not emit an About heading either");
+});
+
+test("whitespace-only @about emits no callout", () => {
+  const sdoc = "# Doc {\n  @about {\n      \n   \n  }\n  # Body {\n    Content.\n  }\n}";
+  const blocks = parseAndRender(sdoc);
+  const docChildren = blocks[0].heading_1.children;
+  assert(!docChildren.some(b => b.type === "callout"), "whitespace-only @about should be treated as empty");
+});
+
+test("@about with content still emits callout (regression guard for empty-skip)", () => {
+  const sdoc = "# Doc {\n  @about {\n    Has content.\n  }\n}";
+  const blocks = parseAndRender(sdoc);
+  const callout = blocks[0].heading_1.children.find(b => b.type === "callout");
+  assert(callout, "non-empty @about should still emit a callout");
+});
+
+// ============================================================
 console.log("\n--- Results: " + pass + " passed, " + fail + " failed ---");
 if (fail > 0) process.exit(1);

--- a/tools/build-doc.js
+++ b/tools/build-doc.js
@@ -2,11 +2,12 @@
 // SDOC Document — CLI tool for HTML and PDF export
 //
 // Usage:
-//   node tools/build-doc.js input.sdoc [-o output] [--html]
+//   node tools/build-doc.js input.sdoc [-o output] [--html] [--include-about]
 //
 // Default output is PDF (requires Chrome/Chromium).
 // Use --html for HTML-only output (no Chrome needed).
 // If -o is omitted, writes to input.pdf (or input.html with --html).
+// The @about scope is hidden by default; pass --include-about to keep it.
 
 const fs = require("fs");
 const path = require("path");
@@ -16,7 +17,7 @@ const { parseSdoc, extractMeta, resolveIncludes, renderHtmlDocumentFromParsed } 
 const CONFIG_FILENAME = "sdoc.config.json";
 
 function usage() {
-  console.error("Usage: build-doc <input.sdoc> [-o output] [--html]");
+  console.error("Usage: build-doc <input.sdoc> [-o output] [--html] [--include-about]");
   process.exit(1);
 }
 
@@ -98,7 +99,8 @@ function resolveMetaStyles(meta, documentPath) {
   return result;
 }
 
-async function buildHtml(filePath) {
+async function buildHtml(filePath, options = {}) {
+  const includeAbout = options.includeAbout === true;
   const resolvedPath = path.resolve(filePath);
   const text = fs.readFileSync(resolvedPath, "utf8");
   const parsed = parseSdoc(text);
@@ -141,6 +143,7 @@ async function buildHtml(filePath) {
       config,
       cssOverride: cssOverride || undefined,
       cssAppend: cssAppendParts.join("\n") || undefined,
+      includeAbout,
     }
   );
 }
@@ -150,12 +153,15 @@ async function main() {
   let inputPath = null;
   let outputPath = null;
   let htmlMode = false;
+  let includeAbout = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "-o" && i + 1 < args.length) {
       outputPath = args[++i];
     } else if (args[i] === "--html") {
       htmlMode = true;
+    } else if (args[i] === "--include-about") {
+      includeAbout = true;
     } else if (args[i] === "--help" || args[i] === "-h") {
       usage();
     } else if (!inputPath) {
@@ -174,7 +180,7 @@ async function main() {
     process.exit(1);
   }
 
-  const html = await buildHtml(resolvedInput);
+  const html = await buildHtml(resolvedInput, { includeAbout });
 
   if (htmlMode) {
     if (!outputPath) {


### PR DESCRIPTION
## Summary                                                                                                                      
                                                                                                                                  
  Reverses the previous decision to hide `@about` from rendered output (#46 / commit `ca7f6d1`). The about scope usually contains  useful framing for human readers — what the document is about, who it's for, when to reach for it — so it makes sense to render it. To keep it visually distinct from body content, it's rendered with a subdued meta-section style (HTML) and a callout block (Notion), making it obvious at a glance that the reader is looking at document metadata rather than the document itself.        
                                                                                                                                  
  ## Why                                                                                                                          
                                                                                                                                  
  `@about` was originally created as a discovery summary for `list_knowledge` and was excluded from rendered output on the grounds that it was "metadata, not content." In practice the about text is the same prose a human would want to read first when opening the file, and hiding it forced authors to duplicate it as a regular intro section. Rendering it — but visibly marked as meta — gives both audiences (the agent doing discovery and the human opening the file) what they need from a single source.            
                                                                                                                                  
  ## Changes                                                                                                                      
                                                                                                                                  
  - **HTML renderer (`src/sdoc.js`):** `@about` scopes (both bare `@about { … }` and heading `# About @about { … }` forms) now emit a `<section class="… sdoc-meta-section">`. Styling: dashed border, muted left rule, italic body, subdued heading, symmetric horizontal margin so the box reads as centered, and a custom toggle position so the collapse caret sits in the gutter rather than on the colored border.                                                                                                     
  - **Notion renderer (`src/notion-renderer.js`):** `@about` scopes render as a Notion `callout` block (ℹ️  icon, gray background). Paragraph children fold into the callout's `rich_text`; lists/tables/images become callout children. The redundant "About" h2 from the heading form is dropped — the callout itself signals what the section is.
  - **Docs (`docs/reference/sdoc-authoring.sdoc`):** Updated the `@about` reference to say it is rendered (with meta-section styling), not hidden.                                                                                                           
  - **Version bump:** `0.2.13` → `0.2.14`.
                                                                                                                                  
  ## Light / dark / Notion parity                                                                                                 
   
  - Light mode and VS Code default theme: ✓ verified in preview.                                                                  
  - VS Code dark + high-contrast themes: borders and text use `var(--sdoc-border)` / `var(--sdoc-muted)` which adapt
  automatically; the box stays readable with a subtle warm background. (A future cleanup could mirror the `darkModeElementsCss`  convention and invert the alpha background — not blocking.)
  - Notion: rendered as `callout` (`gray_background`, ℹ️  icon).                                                                   
  - HTML export with `@media (prefers-color-scheme: dark)`: same as VS Code — vars adapt, layout intact.                          
                                                                                                                                  
 ## Export Behaviour
 
The `@about` section is always visible in live preview and Notion exports.
By default the `@about` section is skipped for html and pdf export. It can be enabled with a flag.
 
  ## Result
  
 ### VS Code Render Dark Mode 
<img width="997" height="411" alt="image" src="https://github.com/user-attachments/assets/04bfc008-725c-48c1-9955-cf5e5be292fc" />

### PDF Export Light Mode
<img width="908" height="504" alt="image" src="https://github.com/user-attachments/assets/82cbef02-7c04-4133-b17d-8d01e7c11e56" />
  
  ## Test plan                                                                                                                    
                                                                                                                                  
  - [x] `node test/test-all.js` — 435/435 pass                                                                                    
  - [x] `node test/test-knr.js` — 24/24 pass
  - [x] `node test/test-notion.js` — 55/55 pass (callout output spot-checked for bare, heading, and list-bearing `@about`)        
  - [x] `node test/test-slides.js` — 43/43 pass                                                                                   
  - [x] `npm run package` builds `vscode-sdoc-0.2.14.vsix` cleanly
  - [x] Manual: VS Code preview shows the meta-section box for both `@about` forms; toggle/collapse caret positions correctly in  the gutter                                                                                                                      
  - [x] Manual: open an HTML export in a browser with dark mode forced and confirm the meta-section is still readable             