### PR TITLE
v0.2.15: Drilldown slides, PDF slide scaling, self-contained image exports

### DIFF
--- a/docs/reference/slide-authoring.sdoc
+++ b/docs/reference/slide-authoring.sdoc
@@ -239,6 +239,84 @@
         }
     }
 
+    # Drilldown Slides @drilldown
+    {
+        A slide deck is normally a 1D spine: Right and Left move along it. A
+        spine slide can also have *vertical detail slides* — extra material
+        you can pull up on demand without cluttering the main flow. Mark a
+        child scope with the `:detail` annotation and it becomes a vertical
+        slide under its parent.
+
+        # Syntax @drilldown-syntax
+        {
+            ```
+            # ETHyR Mechanism @ethyr {
+                Main spine content.
+
+                # PCR primer @pcr :detail {
+                    Detail slide one.
+                }
+
+                # HCR primer @hcr :detail {
+                    Detail slide two.
+                }
+
+                # Notes @notes {
+                    Speaker notes still work alongside details.
+                }
+            }
+            ```
+
+            A detail slide is a regular slide. It can have its own `config:
+            center`, two-column layout, speaker `@notes`, and any other slide
+            content. Drilldowns do not nest further: a `:detail` inside a
+            `:detail` is treated as a plain nested scope.
+        }
+
+        # Navigation @drilldown-navigation
+        {
+            Right — advance one step. From a spine slide, move to the next
+            spine. From a detail slide, advance to the next detail in the
+            same column; at the last detail, return to the parent spine and
+            advance to the next spine (reveal.js convention).
+
+            Left — mirror of Right. From a detail, previous detail or back
+            to parent spine; from spine, previous spine.
+
+            Down — drill into the first detail of the current spine; from
+            within a column, advance to the next detail.
+
+            Up — return from a detail to its parent spine. No-op on a spine.
+
+            Swipe — horizontal swipes mirror Left / Right; vertical swipes
+            mirror Up / Down.
+
+            URL hash — spine slides use `#N`; detail K of spine N uses
+            `#N.K`.
+        }
+
+        # Visual Affordances @drilldown-visual
+        {
+            Spine slides that have detail children get the
+            `slide-has-details` class — the default theme shows a small
+            animated chevron at the bottom of the slide. Themes can replace
+            this rule to fit their own visual language.
+
+            Every slide also gets a `.slide-indicator` element in the
+            bottom-right corner: `5 / 14` on a spine, `5.2 / 14` on detail 2
+            of slide 5. The denominator is always the spine count, so the
+            indicator stays stable as you drill in.
+        }
+
+        # PDF Export @drilldown-pdf
+        {
+            PDF export flattens the deck: spine 1, its details in order,
+            spine 2, its details in order, and so on. This is the same order
+            slides appear in the HTML, so PDF export needs no special case —
+            every slide is just one page.
+        }
+    }
+
     # Theme System @themes
     {
         Themes control the visual appearance of slides. A theme is a directory
@@ -269,17 +347,23 @@
         {
             All themes include these controls by default:
 
-            Arrow right or Space — next slide.
+            Arrow right or Space — next slide (or next detail).
 
-            Arrow left — previous slide.
+            Arrow left — previous slide (or previous detail).
+
+            Arrow down — drill into details (if any).
+
+            Arrow up — return from details to the spine slide.
 
             Home — first slide.
 
-            End — last slide.
+            End — last spine slide.
 
-            Touch swipe left/right on mobile devices.
+            Touch swipe horizontal / vertical on mobile devices.
 
-            Slide counter shown in the bottom-right corner.
+            Slide counter (`.slide-indicator`) shown in the bottom-right
+            corner — `N / TOTAL` on spine slides, `N.K / TOTAL` on detail K
+            of spine N. See [Drilldown Slides](#drilldown) for details.
         }
     }
 

--- a/examples/drilldown-example.sdoc
+++ b/examples/drilldown-example.sdoc
@@ -1,0 +1,98 @@
+# Drilldown Demo {
+    # Meta @meta
+    {
+        type: slides
+
+        title: SDOC Drilldown Demo
+    }
+
+    # SDOC Drilldown
+    {
+        config: center
+
+        Vertical slides under any spine slide.
+
+        Press Right to advance the spine. Press Down to drill in.
+    }
+
+    # Why Drilldown? @why
+    {
+        Sometimes a single slide is a summary and you want a back-pocket of
+        supporting detail you can pull up on demand — without cluttering the
+        main flow.
+
+        # Details — Examples @why-examples :detail
+        {
+            Classic use cases:
+
+            {[.]
+                - Reference figures and source data
+                - Architecture detail behind a high-level diagram
+                - Q&A material for likely questions
+                - Pre-built rebuttals for tough audiences
+            }
+        }
+
+        # Details — Trade-offs @why-tradeoffs :detail
+        {
+            What you give up:
+
+            {[.]
+                - Linear PDF export still flattens everything
+                - Audiences in a 1D viewer never see the details
+                - Authoring discipline: don't hide the punch line below the fold
+            }
+        }
+    }
+
+    # Spine Slide With No Details
+    {
+        Not every spine slide needs detail children. This one is just a
+        regular slide — Right and Left move you along the spine as usual.
+    }
+
+    # ETHyR Mechanism @ethyr-mechanism
+    {
+        ETHyR turns DNA into a measurable hybridisation signal you can read
+        with a phone-sized device.
+
+        # PCR primer @pcr-detail :detail
+        {
+            PCR amplifies target DNA exponentially using thermal cycling:
+
+            {[#]
+                - Denature: heat to ~95 °C to split the double helix
+                - Anneal: cool to ~55 °C so primers bind their targets
+                - Extend: polymerase synthesises the complementary strand
+            }
+
+            Doubles the target every cycle for ~30 cycles.
+        }
+
+        # HCR primer @hcr-detail :detail
+        {
+            Hybridisation Chain Reaction is isothermal: no thermal cycler
+            needed.
+
+            {[.]
+                - Two metastable hairpin species sit in solution
+                - A target sequence opens the first hairpin
+                - A chain reaction extends a long fluorescent polymer
+            }
+
+            Output scales linearly with target concentration.
+        }
+
+        # Notes @notes
+        {
+            If asked about thermal control, drill into the PCR primer slide.
+        }
+    }
+
+    # Thank You
+    {
+        config: center
+
+        Questions?
+    }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sdoc",
   "displayName": "SDOC - Docs for Human/Agent Teams",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "publisher": "entropicwarrior-msenfin",
   "license": "MIT",
   "repository": {

--- a/src/extension.js
+++ b/src/extension.js
@@ -1395,7 +1395,7 @@ async function buildCleanHtml(document, exportOptions = {}) {
   cssAppendParts.push(buildCollapseCss());
   cssAppendParts.push(buildExportDarkModeCss());
 
-  return renderHtmlDocumentFromParsed(
+  const html = renderHtmlDocumentFromParsed(
     { nodes: metaResult.nodes, errors: parsed.errors },
     title,
     {
@@ -1408,6 +1408,39 @@ async function buildCleanHtml(document, exportOptions = {}) {
       includeAbout
     }
   );
+
+  // Inline local images as data URIs so exports are self-contained. PDF export
+  // and Open in Browser render from a temp directory, where relative image
+  // paths (e.g. diagrams/foo.svg) no longer resolve; inlining also makes the
+  // exported HTML portable.
+  return inlineLocalImages(html, docDir);
+}
+
+const EXPORT_IMAGE_MIME = {
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+function inlineLocalImages(html, docDir) {
+  return html.replace(/(<img\b[^>]*?\bsrc=")([^"]*)(")/gi, (match, pre, src, post) => {
+    if (/^(https?:|data:|file:|vscode-)/i.test(src)) return match;
+    const decoded = src.replace(/&amp;/g, "&");
+    const ext = path.extname(decoded).toLowerCase();
+    const mime = EXPORT_IMAGE_MIME[ext];
+    if (!mime) return match;
+    const abs = path.isAbsolute(decoded) ? decoded : path.join(docDir, decoded);
+    let data;
+    try {
+      data = fs.readFileSync(abs);
+    } catch {
+      return match;
+    }
+    return `${pre}data:${mime};base64,${data.toString("base64")}${post}`;
+  });
 }
 
 async function exportHtml(exportOptions = {}) {

--- a/src/slide-renderer.js
+++ b/src/slide-renderer.js
@@ -275,21 +275,25 @@ function renderSlide(scope, slideIndex, overlayHtml, position) {
     : "";
 
   const idAttr = scope.id ? ` id="${escapeAttr(scope.id)}"` : "";
-  const overlay = overlayHtml || "";
 
-  // Drilldown metadata + indicator
+  // Drilldown metadata + slide indicator label (substituted into the footer)
   let dataAttrs = "";
-  let indicatorHtml = "";
+  let indicatorLabel = "";
   if (position) {
     dataAttrs = ` data-spine="${position.spine}" data-detail="${position.detail}"`;
     const denom = position.totalSpines;
-    const label = position.detail === 0
+    indicatorLabel = position.detail === 0
       ? `${position.spine} / ${denom}`
       : `${position.spine}.${position.detail} / ${denom}`;
-    indicatorHtml = `\n<div class="slide-indicator">${escapeHtml(label)}</div>`;
   }
+  const overlay = (overlayHtml || "").replace("__SLIDE_INDICATOR__", escapeHtml(indicatorLabel));
 
-  return `<div class="${classes.join(" ")}"${idAttr}${dataAttrs}>\n${title}\n${bodyHtml}${notesHtml}${overlay}${indicatorHtml}\n</div>`;
+  // Wrap title + body in a scale container so PDF export can apply
+  // transform: scale() to fit the content onto a fixed page size.  In
+  // screen mode the wrapper is display:contents (invisible to layout); in
+  // print mode it becomes a real block that the beforeprint handler can
+  // measure and scale.
+  return `<div class="${classes.join(" ")}"${idAttr}${dataAttrs}>\n<div class="slide-content-scale">\n${title}\n${bodyHtml}\n</div>${notesHtml}${overlay}\n</div>`;
 }
 
 // ---------------------------------------------------------------------------
@@ -316,7 +320,11 @@ function renderSlides(nodes, options = {}) {
   // Filter to scope nodes only (skip stray paragraphs and :comment scopes)
   const slides = slideScopes.filter((n) => n.type === "scope" && n.scopeType !== "comment");
 
-  // Build per-slide footer: <  CONFIDENTIAL  ---gap---  Company  >
+  // Build per-slide footer:
+  //   <  CONFIDENTIAL  ---gap---  Company  N/Total  >
+  // The indicator slot is rendered as a literal token here and substituted
+  // per-slide inside renderSlide() so all the right-edge elements share one
+  // flexbox row (avoids the page number stacking on top of the company name).
   const footerParts = [];
   footerParts.push(`<span class="nav-prev">&lsaquo;</span>`);
   if (meta.confidential) {
@@ -331,6 +339,7 @@ function renderSlides(nodes, options = {}) {
   if (meta.company) {
     footerParts.push(`<span class="sdoc-company-footer">${escapeHtml(meta.company)}</span>`);
   }
+  footerParts.push(`<span class="slide-indicator">__SLIDE_INDICATOR__</span>`);
   footerParts.push(`<span class="nav-next">&rsaquo;</span>`);
   const overlayHtml = `\n<div class="slide-footer">${footerParts.join("")}</div>`;
 
@@ -397,26 +406,38 @@ function renderSlides(nodes, options = {}) {
   margin-left: 0.8em;
 }
 .slide-indicator {
-  position: absolute; bottom: 20px; right: 32px;
   font-size: 0.7em; color: rgba(0,0,0,0.35);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.04em;
   pointer-events: none;
   user-select: none;
+  margin-right: 0.6em;
 }
+/* Scale wrapper: invisible to layout in screen mode so existing slide
+   styles (flex centering, two-column grid, etc.) work as-is.  In print
+   mode it becomes a real block element whose transform is set by the
+   beforeprint handler to shrink overflowing content to fit the page. */
+.slide-content-scale { display: contents; }
+
 @media print {
   @page { size: 13.333in 7.5in; margin: 0; }
   body { overflow: visible; height: auto; }
   .slide {
-    display: flex !important;
+    display: block !important;
     position: relative !important;
     opacity: 1 !important;
     pointer-events: auto !important;
     page-break-after: always; break-after: page;
     width: 100vw; height: 100vh; max-width: none;
+    overflow: hidden;
     page-break-inside: avoid; break-inside: avoid;
   }
   .slide:last-child { page-break-after: auto; break-after: auto; }
+  .slide-content-scale {
+    display: block;
+    width: 100%;
+    transform-origin: top left;
+  }
   .nav-prev, .nav-next { display: none !important; }
   .notes { display: none; }
 }`;

--- a/src/slide-renderer.js
+++ b/src/slide-renderer.js
@@ -206,17 +206,44 @@ function extractNotes(children) {
   return { notes, contentNodes: rest };
 }
 
+// Separates :detail child scopes (drilldown / vertical slides) from other
+// children. Detail scopes are NOT removed from rendering; they are emitted as
+// sibling slides positioned vertically under the spine slide.
+function extractDetails(children) {
+  const details = [];
+  const rest = [];
+  for (const child of children) {
+    if (child.type === "scope" && child.scopeType === "detail") {
+      details.push(child);
+    } else {
+      rest.push(child);
+    }
+  }
+  return { details, contentNodes: rest };
+}
+
 // ---------------------------------------------------------------------------
 // Slide rendering
 // ---------------------------------------------------------------------------
 
-function renderSlide(scope, slideIndex, overlayHtml) {
-  const { config, contentNodes: afterConfig } = extractSlideConfig(scope.children);
+// position: { spine: 1-based spine index, detail: 0 for spine, 1..N for details,
+//             totalSpines: total number of spine slides, hasDetails: bool (spine only) }
+function renderSlide(scope, slideIndex, overlayHtml, position) {
+  // Pull :detail children out first so they don't appear inline in the spine
+  // slide's content; they're rendered as sibling vertical slides instead.
+  const { contentNodes: afterDetails } = extractDetails(scope.children);
+  const { config, contentNodes: afterConfig } = extractSlideConfig(afterDetails);
   const { notes, contentNodes } = extractNotes(afterConfig);
 
   const classes = ["slide"];
   if (config.layout) {
     classes.push(config.layout);
+  }
+  if (position && position.detail === 0 && position.hasDetails) {
+    classes.push("slide-has-details");
+  }
+  if (position && position.detail > 0) {
+    classes.push("slide-detail");
   }
 
   const title = scope.hasHeading !== false && scope.title
@@ -250,7 +277,19 @@ function renderSlide(scope, slideIndex, overlayHtml) {
   const idAttr = scope.id ? ` id="${escapeAttr(scope.id)}"` : "";
   const overlay = overlayHtml || "";
 
-  return `<div class="${classes.join(" ")}"${idAttr}>\n${title}\n${bodyHtml}${notesHtml}${overlay}\n</div>`;
+  // Drilldown metadata + indicator
+  let dataAttrs = "";
+  let indicatorHtml = "";
+  if (position) {
+    dataAttrs = ` data-spine="${position.spine}" data-detail="${position.detail}"`;
+    const denom = position.totalSpines;
+    const label = position.detail === 0
+      ? `${position.spine} / ${denom}`
+      : `${position.spine}.${position.detail} / ${denom}`;
+    indicatorHtml = `\n<div class="slide-indicator">${escapeHtml(label)}</div>`;
+  }
+
+  return `<div class="${classes.join(" ")}"${idAttr}${dataAttrs}>\n${title}\n${bodyHtml}${notesHtml}${overlay}${indicatorHtml}\n</div>`;
 }
 
 // ---------------------------------------------------------------------------
@@ -295,8 +334,38 @@ function renderSlides(nodes, options = {}) {
   footerParts.push(`<span class="nav-next">&rsaquo;</span>`);
   const overlayHtml = `\n<div class="slide-footer">${footerParts.join("")}</div>`;
 
-  const slidesHtml = slides
-    .map((scope, index) => renderSlide(scope, index, overlayHtml))
+  // Build a flat emission order: each spine slide, followed immediately by its
+  // :detail children in source order. The flat order matches what we want for
+  // PDF export, so PDF needs no special case.
+  const totalSpines = slides.length;
+  const emitted = [];
+  slides.forEach((scope, i) => {
+    const spineIndex = i + 1; // 1-based
+    const { details } = extractDetails(scope.children);
+    emitted.push({
+      scope,
+      position: {
+        spine: spineIndex,
+        detail: 0,
+        totalSpines,
+        hasDetails: details.length > 0
+      }
+    });
+    details.forEach((detail, j) => {
+      emitted.push({
+        scope: detail,
+        position: {
+          spine: spineIndex,
+          detail: j + 1,
+          totalSpines,
+          hasDetails: false
+        }
+      });
+    });
+  });
+
+  const slidesHtml = emitted
+    .map(({ scope, position }, index) => renderSlide(scope, index, overlayHtml, position))
     .join("\n\n");
 
   const title = meta.properties?.title
@@ -326,6 +395,14 @@ function renderSlides(nodes, options = {}) {
   letter-spacing: 0.12em; text-transform: uppercase;
   color: rgba(160, 40, 40, 0.6);
   margin-left: 0.8em;
+}
+.slide-indicator {
+  position: absolute; bottom: 20px; right: 32px;
+  font-size: 0.7em; color: rgba(0,0,0,0.35);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  pointer-events: none;
+  user-select: none;
 }
 @media print {
   @page { size: 13.333in 7.5in; margin: 0; }
@@ -359,6 +436,7 @@ blockquote p { color: #9d9d9d; }
 .nav-prev, .nav-next { color: rgba(255, 255, 255, 0.7); }
 .sdoc-company-footer { color: rgba(255, 255, 255, 0.35); }
 .sdoc-confidential-notice { color: rgba(235, 120, 120, 0.7); }
+.slide-indicator { color: rgba(255, 255, 255, 0.35); }
 ` : "";
 
   const cssTag = `<style>\n${structuralCss}\n${themeCss}\n${darkCss}</style>`;

--- a/test/test-slides.js
+++ b/test/test-slides.js
@@ -47,7 +47,7 @@ test("single slide", () => {
     }
 }
 `);
-  assert(html.includes('<div class="slide">'), "should have slide div");
+  assert(html.includes('<div class="slide"'), "should have slide div");
   assert(html.includes("<h2>Hello World</h2>"), "should have slide title");
   assert(html.includes("<p>This is a slide.</p>"), "should have paragraph");
 });
@@ -63,7 +63,7 @@ test("multiple slides", () => {
     }
 }
 `);
-  const slideCount = (html.match(/<div class="slide">/g) || []).length;
+  const slideCount = (html.match(/<div class="slide"/g) || []).length;
   assert(slideCount === 2, "should have 2 slides, got " + slideCount);
   assert(html.includes("<h2>Slide One</h2>"), "should have first title");
   assert(html.includes("<h2>Slide Two</h2>"), "should have second title");
@@ -110,7 +110,7 @@ test("meta scope is excluded from slides", () => {
     }
 }
 `);
-  const slideCount = (html.match(/<div class="slide">/g) || []).length;
+  const slideCount = (html.match(/<div class="slide"/g) || []).length;
   assert(slideCount === 1, "meta should not become a slide, got " + slideCount);
 });
 
@@ -212,7 +212,7 @@ test("notes are separated from content", () => {
 }
 `);
   // Notes should not appear inside the main slide content flow
-  const slideDiv = html.match(/<div class="slide">([\s\S]*?)<\/div>/);
+  const slideDiv = html.match(/<div class="slide"[^>]*>([\s\S]*?)<\/div>/);
   assert(slideDiv, "should have slide div");
   assert(slideDiv[1].includes("Content."), "content in slide");
   assert(slideDiv[1].includes('<aside class="notes">'), "notes in slide as aside");
@@ -418,7 +418,7 @@ test("empty slide", () => {
     }
 }
 `);
-  assert(html.includes('<div class="slide">'), "should still render slide");
+  assert(html.includes('<div class="slide"'), "should still render slide");
   assert(html.includes("<h2>Empty Slide</h2>"), "should still have title");
 });
 
@@ -701,6 +701,173 @@ test("svg block in slide strips script tags", () => {
 `);
   assert(!html.includes("<script"), "should strip script from slide SVG");
   assert(html.includes("<rect/>"), "should keep safe elements");
+});
+
+// ============================================================
+console.log("\n--- Drilldown (vertical) slides ---");
+
+test("plain 1D deck still gets spine/detail metadata but no detail slides", () => {
+  const html = parseAndRender(`
+# Deck {
+    # Slide One { First. }
+    # Slide Two { Second. }
+}
+`);
+  const slideCount = (html.match(/<div class="slide"/g) || []).length;
+  assert(slideCount === 2, "1D deck still has 2 slides, got " + slideCount);
+  assert(html.includes('data-spine="1"'), "spine 1 attr present");
+  assert(html.includes('data-spine="2"'), "spine 2 attr present");
+  assert(html.includes('data-detail="0"'), "detail=0 attr on spine slides");
+  assert(!html.includes('data-detail="1"'), "no detail slides emitted");
+  assert(!html.includes("slide-has-details"), "no has-details class for 1D deck");
+});
+
+test("slide-indicator shows spine count denominator", () => {
+  const html = parseAndRender(`
+# Deck {
+    # A { aaa }
+    # B { bbb }
+    # C { ccc }
+}
+`);
+  assert(html.includes('class="slide-indicator">1 / 3'), "first slide indicator");
+  assert(html.includes('class="slide-indicator">2 / 3'), "second slide indicator");
+  assert(html.includes('class="slide-indicator">3 / 3'), "third slide indicator");
+});
+
+test(":detail children become sibling slides", () => {
+  const html = parseAndRender(`
+# Deck {
+    # Spine @spine1 {
+        Main content here.
+
+        # Detail one @det1 :detail {
+            First drilldown.
+        }
+
+        # Detail two @det2 :detail {
+            Second drilldown.
+        }
+    }
+    # Next @spine2 {
+        Plain.
+    }
+}
+`);
+  // Three slides total: spine1, det1, det2... plus spine2 = 4
+  const slideCount = (html.match(/<div class="slide[^"]*"[^>]*data-spine=/g) || []).length;
+  assert(slideCount === 4, "expected 4 emitted slides (2 spines + 2 details), got " + slideCount);
+  assert(html.includes('data-spine="1" data-detail="0"'), "spine 1 attrs");
+  assert(html.includes('data-spine="1" data-detail="1"'), "detail 1 attrs");
+  assert(html.includes('data-spine="1" data-detail="2"'), "detail 2 attrs");
+  assert(html.includes('data-spine="2" data-detail="0"'), "spine 2 attrs");
+});
+
+test("emission order is spine then its details then next spine (PDF flattening)", () => {
+  const html = parseAndRender(`
+# Deck {
+    # First @first {
+        # D1 @d1 :detail {
+            d1 body
+        }
+        # D2 @d2 :detail {
+            d2 body
+        }
+    }
+    # Second @second {
+        Second body.
+    }
+}
+`);
+  const iFirst = html.indexOf('id="first"');
+  const iD1 = html.indexOf('id="d1"');
+  const iD2 = html.indexOf('id="d2"');
+  const iSecond = html.indexOf('id="second"');
+  assert(iFirst >= 0 && iD1 >= 0 && iD2 >= 0 && iSecond >= 0,
+    "all anchor ids found (first=" + iFirst + " d1=" + iD1 + " d2=" + iD2 + " second=" + iSecond + ")");
+  assert(iFirst < iD1 && iD1 < iD2 && iD2 < iSecond, "order should be first, d1, d2, second");
+});
+
+test("spine with details gets slide-has-details class; details do not", () => {
+  const html = parseAndRender(`
+# Deck {
+    # Spine {
+        # Detail @det :detail {
+            Detail body.
+        }
+    }
+}
+`);
+  // Spine has class slide-has-details; the detail itself does not.
+  const spineMatch = html.match(/<div class="([^"]*)"[^>]*data-spine="1" data-detail="0"/);
+  assert(spineMatch, "spine slide div found");
+  assert(spineMatch[1].split(/\s+/).includes("slide-has-details"), "spine has slide-has-details");
+  const detailMatch = html.match(/<div class="([^"]*)"[^>]*data-spine="1" data-detail="1"/);
+  assert(detailMatch, "detail slide div found");
+  assert(!detailMatch[1].split(/\s+/).includes("slide-has-details"), "detail does not have slide-has-details");
+  assert(detailMatch[1].split(/\s+/).includes("slide-detail"), "detail has slide-detail class");
+});
+
+test("detail slide indicator uses N.K notation", () => {
+  const html = parseAndRender(`
+# Deck {
+    # A {
+        # D :detail {
+            d1
+        }
+        # E :detail {
+            d2
+        }
+    }
+    # B {
+        plain
+    }
+}
+`);
+  assert(html.includes('class="slide-indicator">1 / 2'), "spine indicator");
+  assert(html.includes('class="slide-indicator">1.1 / 2'), "first detail indicator");
+  assert(html.includes('class="slide-indicator">1.2 / 2'), "second detail indicator");
+  assert(html.includes('class="slide-indicator">2 / 2'), "second spine indicator");
+});
+
+test(":detail children are pulled out of spine slide content", () => {
+  const html = parseAndRender(`
+# Deck {
+    # Spine {
+        Main paragraph.
+
+        # Drill @det :detail {
+            Drilled content.
+        }
+    }
+}
+`);
+  // The spine slide's body should NOT contain the detail's h2; only its own.
+  // Easiest check: detail content must appear in a separate slide element,
+  // and the spine's <section> nested rendering of the detail must not exist.
+  const spineMatch = html.match(/<div class="[^"]*"[^>]*data-spine="1" data-detail="0"[^>]*>([\s\S]*?)<\/div>(?=\s*<div class="slide)/);
+  assert(spineMatch, "spine slide HTML extracted");
+  assert(spineMatch[1].includes("Main paragraph."), "spine still contains its own paragraph");
+  assert(!spineMatch[1].includes("Drilled content."), "spine slide body should NOT contain detail body");
+  assert(html.includes("Drilled content."), "detail body present elsewhere in document");
+});
+
+test("detail slide can use config: center", () => {
+  const html = parseAndRender(`
+# Deck {
+    # Spine {
+        # Drill :detail {
+            config: center
+
+            Centered drilldown.
+        }
+    }
+}
+`);
+  // The detail slide should carry the "center" layout class.
+  const m = html.match(/<div class="([^"]*)"[^>]*data-spine="1" data-detail="1"/);
+  assert(m, "detail slide found");
+  assert(m[1].split(/\s+/).includes("center"), "detail has center class");
 });
 
 // ============================================================

--- a/test/test-slides.js
+++ b/test/test-slides.js
@@ -211,11 +211,14 @@ test("notes are separated from content", () => {
     }
 }
 `);
-  // Notes should not appear inside the main slide content flow
-  const slideDiv = html.match(/<div class="slide"[^>]*>([\s\S]*?)<\/div>/);
-  assert(slideDiv, "should have slide div");
-  assert(slideDiv[1].includes("Content."), "content in slide");
-  assert(slideDiv[1].includes('<aside class="notes">'), "notes in slide as aside");
+  assert(html.includes("Content."), "content present");
+  assert(html.includes('<aside class="notes">'), "notes rendered as aside");
+  // Notes live outside the .slide-content-scale wrapper (sibling, not child),
+  // confirming they are separate from the main slide content flow.
+  const scaleOpen = html.indexOf('class="slide-content-scale"');
+  const scaleClose = html.indexOf('</div>', scaleOpen);
+  const notesStart = html.indexOf('<aside class="notes">');
+  assert(notesStart > scaleClose, "notes appear after the content-scale wrapper, not inside it");
 });
 
 // ============================================================
@@ -446,7 +449,7 @@ test("rendered slides include print styles", () => {
 `);
   assert(html.includes("@media print"), "should have @media print block");
   assert(html.includes("page-break-after"), "should have page-break rules");
-  assert(html.includes("display: flex !important"), "should force slides visible in print");
+  assert(html.includes("display: block !important"), "should force slides visible in print");
 });
 
 test("findChrome returns a string or null", () => {

--- a/themes/default/theme.css
+++ b/themes/default/theme.css
@@ -158,6 +158,32 @@ img {
   display: none;
 }
 
+/* --- Drilldown affordance ---
+   Spine slides that have :detail children get .slide-has-details. The default
+   theme renders a small downward chevron in the bottom-centre to hint that
+   pressing Down (or swiping up) drills in. Custom themes (e.g. ETHyR) can
+   replace this rule with their own animation. */
+
+.slide-has-details::after {
+  content: "\2304"; /* ⌄ — DOWN ARROWHEAD */
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 1.2em;
+  color: rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+  animation: slide-has-details-bounce 1.8s ease-in-out infinite;
+}
+
+@keyframes slide-has-details-bounce {
+  0%, 100% { transform: translate(-50%, 0); opacity: 0.4; }
+  50%      { transform: translate(-50%, 4px); opacity: 0.8; }
+}
+
+/* Slide indicator base style is injected structurally by the renderer.
+   Themes may override .slide-indicator to restyle it. */
+
 
 /* Print / PDF styles are injected by the renderer (slide-renderer.js)
    so they work with every theme, not just this one. */

--- a/themes/default/theme.js
+++ b/themes/default/theme.js
@@ -174,4 +174,66 @@
     var p = parseHash(window.location.hash);
     if (p) show(p.s, p.d);
   });
+
+  // ---------------------------------------------------------------------
+  // PDF / print rendering: measure each slide's natural content size and
+  // apply transform: scale() so the content fits the page exactly.  In
+  // screen mode .slide-content-scale is display:contents (invisible to
+  // layout); in print mode it becomes display:block, at which point we
+  // can measure its scrollWidth / scrollHeight and shrink to fit.
+  // ---------------------------------------------------------------------
+  function fitSlidesForPrint() {
+    var allSlides = document.querySelectorAll(".slide");
+    for (var i = 0; i < allSlides.length; i++) {
+      var slide = allSlides[i];
+      var wrap = slide.querySelector(".slide-content-scale");
+      if (!wrap) continue;
+      // Reset any prior transform so the natural size can be measured.
+      wrap.style.transform = "";
+      // Use the slide's box as the target — print CSS sets it to the
+      // page size (100vw x 100vh, which in print is 13.333in x 7.5in).
+      var rect = slide.getBoundingClientRect();
+      var pageW = rect.width;
+      var pageH = rect.height;
+      var contentW = wrap.scrollWidth;
+      var contentH = wrap.scrollHeight;
+      if (contentW <= 0 || contentH <= 0 || pageW <= 0 || pageH <= 0) continue;
+      var s = Math.min(pageW / contentW, pageH / contentH, 1);
+      if (s < 0.999) {
+        wrap.style.transform = "scale(" + s + ")";
+      }
+    }
+  }
+  function unfitSlidesAfterPrint() {
+    var wraps = document.querySelectorAll(".slide-content-scale");
+    for (var i = 0; i < wraps.length; i++) wraps[i].style.transform = "";
+  }
+  window.addEventListener("beforeprint", fitSlidesForPrint);
+  window.addEventListener("afterprint", unfitSlidesAfterPrint);
+  // Headless Chrome --print-to-pdf typically renders the whole page with
+  // print CSS active from the start; neither beforeprint nor matchMedia
+  // "change" fires (there is no change — print is the initial state).
+  // Run fitSlidesForPrint as soon as layout is stable so scaling applies
+  // before Chrome captures the page.  In screen mode the wrapper is
+  // display:contents so scrollWidth/scrollHeight return 0 and the guard
+  // inside fitSlidesForPrint makes this a no-op.
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(function () { requestAnimationFrame(fitSlidesForPrint); });
+  } else {
+    fitSlidesForPrint();
+  }
+  if (document.readyState === "complete") {
+    fitSlidesForPrint();
+  } else {
+    window.addEventListener("load", fitSlidesForPrint);
+  }
+  // Also fit when the print media query toggles (interactive Cmd+P).
+  if (window.matchMedia) {
+    var mq = window.matchMedia("print");
+    if (mq.addEventListener) {
+      mq.addEventListener("change", function (ev) {
+        if (ev.matches) fitSlidesForPrint(); else unfitSlidesAfterPrint();
+      });
+    }
+  }
 })();

--- a/themes/default/theme.js
+++ b/themes/default/theme.js
@@ -1,79 +1,177 @@
 // SDOC Slides — Default Theme Runtime
 // Keyboard navigation, click navigation, touch swipe, URL hash, nav indicators.
+//
+// Slides form a 2D grid: a horizontal spine of top-level slides, with optional
+// vertical "detail" columns under any spine slide. Each .slide element carries
+// data-spine (1-based) and data-detail (0 = spine, 1..N = nth detail). Decks
+// without :detail children behave exactly like a 1D deck.
 
 (function () {
-  const slides = document.querySelectorAll(".slide");
-  let current = 0;
+  var slides = Array.prototype.slice.call(document.querySelectorAll(".slide"));
+  if (slides.length === 0) return;
 
-  function show(n) {
-    slides[current].classList.remove("active");
-    current = Math.max(0, Math.min(n, slides.length - 1));
-    slides[current].classList.add("active");
-    // Update nav indicators on all slides
-    slides.forEach(function (slide, i) {
+  // Build a 2D grid: columns[s-1] = [spineSlide, detail1, detail2, ...]
+  var columns = [];
+  slides.forEach(function (el) {
+    var s = parseInt(el.getAttribute("data-spine") || "0", 10);
+    var d = parseInt(el.getAttribute("data-detail") || "0", 10);
+    if (!s) return; // slides without position info (shouldn't happen) — skip
+    if (!columns[s - 1]) columns[s - 1] = [];
+    columns[s - 1][d] = el;
+  });
+  // Fallback: if no data-spine attributes are present (custom themes / older
+  // renderers), treat every slide as its own spine column.
+  if (columns.length === 0) {
+    slides.forEach(function (el, i) { columns[i] = [el]; });
+  }
+
+  var spineCount = columns.length;
+  var cur = { s: 0, d: 0 }; // 0-based indices
+
+  function clamp(n, lo, hi) { return Math.max(lo, Math.min(n, hi)); }
+
+  function activeEl() {
+    var col = columns[cur.s];
+    if (!col) return null;
+    return col[cur.d] || col[0];
+  }
+
+  function show(s, d) {
+    // Hide currently active slide
+    var prevEl = activeEl();
+    if (prevEl) prevEl.classList.remove("active");
+
+    cur.s = clamp(s, 0, spineCount - 1);
+    var col = columns[cur.s] || [];
+    // Detail count for this spine = col.length - 1 (index 0 is the spine itself)
+    var maxDetail = Math.max(0, col.length - 1);
+    cur.d = clamp(d, 0, maxDetail);
+
+    var el = activeEl();
+    if (el) el.classList.add("active");
+
+    // Update nav indicator visibility per slide. In the flat slide order,
+    // a slide is "first" if it is the very first emitted slide, and "last"
+    // if it is the very last; in between, every slide has a next/prev in
+    // the flat sequence. We mirror the prior 1D behaviour: show chevrons
+    // when there is something to move to in the *flat* sequence.
+    var flatIndex = 0;
+    var totalFlat = slides.length;
+    for (var si = 0; si < cur.s; si++) {
+      flatIndex += (columns[si] || [{}]).length;
+    }
+    flatIndex += cur.d;
+
+    slides.forEach(function (slide) {
       var prev = slide.querySelector(".nav-prev");
       var next = slide.querySelector(".nav-next");
-      if (prev) prev.style.visibility = i > 0 ? "visible" : "hidden";
-      if (next) next.style.visibility = i < slides.length - 1 ? "visible" : "hidden";
+      if (prev) prev.style.visibility = flatIndex > 0 ? "visible" : "hidden";
+      if (next) next.style.visibility = flatIndex < totalFlat - 1 ? "visible" : "hidden";
     });
-    // Update URL hash without triggering hashchange
-    history.replaceState(null, "", "#" + (current + 1));
+
+    // URL hash: "N" for spine, "N.K" for detail K of spine N (1-based)
+    var hashVal = (cur.s + 1) + (cur.d > 0 ? "." + cur.d : "");
+    history.replaceState(null, "", "#" + hashVal);
+  }
+
+  // Move horizontally one step. On a detail, advance through remaining details
+  // in the column, then return to the parent spine and advance to next spine.
+  function nextStep() {
+    var col = columns[cur.s] || [];
+    if (cur.d > 0 && cur.d < col.length - 1) {
+      show(cur.s, cur.d + 1);
+      return;
+    }
+    if (cur.s < spineCount - 1) {
+      show(cur.s + 1, 0);
+    }
+  }
+
+  function prevStep() {
+    if (cur.d > 0) {
+      show(cur.s, cur.d - 1);
+      return;
+    }
+    if (cur.s > 0) {
+      show(cur.s - 1, 0);
+    }
+  }
+
+  function downStep() {
+    var col = columns[cur.s] || [];
+    if (cur.d < col.length - 1) {
+      show(cur.s, cur.d + 1);
+    }
+  }
+
+  function upStep() {
+    if (cur.d > 0) {
+      show(cur.s, 0);
+    }
   }
 
   document.addEventListener("keydown", function (e) {
     if (e.key === "ArrowRight" || e.key === " ") {
       e.preventDefault();
-      show(current + 1);
-    }
-    if (e.key === "ArrowLeft") {
+      nextStep();
+    } else if (e.key === "ArrowLeft") {
       e.preventDefault();
-      show(current - 1);
-    }
-    if (e.key === "Home") {
+      prevStep();
+    } else if (e.key === "ArrowDown") {
       e.preventDefault();
-      show(0);
-    }
-    if (e.key === "End") {
+      downStep();
+    } else if (e.key === "ArrowUp") {
       e.preventDefault();
-      show(slides.length - 1);
+      upStep();
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      show(0, 0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      show(spineCount - 1, 0);
     }
   });
 
-  // Click navigation — right half forward, left half back
+  // Click navigation — right half forward, left half back (spine only)
   document.addEventListener("click", function (e) {
-    // Ignore clicks on links, buttons, or interactive elements
     if (e.target.closest("a, button, input, textarea, select")) return;
     if (e.clientX > window.innerWidth / 2) {
-      show(current + 1);
+      nextStep();
     } else {
-      show(current - 1);
+      prevStep();
     }
   });
 
-  // Touch swipe support
-  var touchStartX = 0;
+  // Touch swipe — horizontal for spine/next-step, vertical for drilldown
+  var touchStartX = 0, touchStartY = 0;
   document.addEventListener("touchstart", function (e) {
     touchStartX = e.touches[0].clientX;
+    touchStartY = e.touches[0].clientY;
   });
   document.addEventListener("touchend", function (e) {
     var dx = e.changedTouches[0].clientX - touchStartX;
-    if (dx < -50) show(current + 1);
-    if (dx > 50) show(current - 1);
+    var dy = e.changedTouches[0].clientY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy)) {
+      if (dx < -50) nextStep();
+      else if (dx > 50) prevStep();
+    } else {
+      if (dy < -50) downStep();
+      else if (dy > 50) upStep();
+    }
   });
 
-  // Read initial slide from URL hash
-  var startSlide = 0;
-  var hash = window.location.hash;
-  if (hash && hash.match(/^#\d+$/)) {
-    startSlide = parseInt(hash.substring(1), 10) - 1;
+  // Parse "#N" or "#N.K" hash
+  function parseHash(hash) {
+    var m = /^#(\d+)(?:\.(\d+))?$/.exec(hash || "");
+    if (!m) return null;
+    return { s: parseInt(m[1], 10) - 1, d: m[2] ? parseInt(m[2], 10) : 0 };
   }
-  show(startSlide);
 
-  // Handle back/forward browser navigation
+  var initial = parseHash(window.location.hash) || { s: 0, d: 0 };
+  show(initial.s, initial.d);
+
   window.addEventListener("hashchange", function () {
-    var h = window.location.hash;
-    if (h && h.match(/^#\d+$/)) {
-      show(parseInt(h.substring(1), 10) - 1);
-    }
+    var p = parseHash(window.location.hash);
+    if (p) show(p.s, p.d);
   });
 })();

--- a/tools/build-doc.js
+++ b/tools/build-doc.js
@@ -135,7 +135,7 @@ async function buildHtml(filePath, options = {}) {
 
   const title = path.basename(resolvedPath, ".sdoc");
 
-  return renderHtmlDocumentFromParsed(
+  const html = renderHtmlDocumentFromParsed(
     { nodes: metaResult.nodes, errors: parsed.errors },
     title,
     {
@@ -146,6 +146,41 @@ async function buildHtml(filePath, options = {}) {
       includeAbout,
     }
   );
+
+  // Inline local images as data URIs so output is self-contained. PDF export
+  // renders from a temp directory, where relative image paths (e.g.
+  // diagrams/foo.svg) no longer resolve; inlining also makes HTML portable.
+  return inlineLocalImages(html, docDir);
+}
+
+const IMAGE_MIME = {
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+function inlineLocalImages(html, docDir) {
+  return html.replace(/(<img\b[^>]*?\bsrc=")([^"]*)(")/gi, (match, pre, src, post) => {
+    // Leave remote URLs and already-inlined data URIs untouched.
+    if (/^(https?:|data:|file:)/i.test(src)) return match;
+    const decoded = src.replace(/&amp;/g, "&");
+    const ext = path.extname(decoded).toLowerCase();
+    const mime = IMAGE_MIME[ext];
+    if (!mime) return match;
+    const abs = path.isAbsolute(decoded) ? decoded : path.join(docDir, decoded);
+    let data;
+    try {
+      data = fs.readFileSync(abs);
+    } catch {
+      console.error(`Warning: could not inline image (not found): ${decoded}`);
+      return match;
+    }
+    const uri = `data:${mime};base64,${data.toString("base64")}`;
+    return `${pre}${uri}${post}`;
+  });
 }
 
 async function main() {
@@ -197,6 +232,7 @@ async function main() {
       outputPath = resolvedInput.replace(/\.sdoc$/i, "") + ".pdf";
     }
     const resolvedOutput = path.resolve(outputPath);
+    fs.mkdirSync(path.dirname(resolvedOutput), { recursive: true });
 
     // Write HTML to temp file for Chrome
     const tmpHtml = path.join(os.tmpdir(), "sdoc-doc-" + Date.now() + ".html");

--- a/tools/build-slides.js
+++ b/tools/build-slides.js
@@ -108,8 +108,13 @@ async function main() {
       pdfOutput = resolvedInput.replace(/\.sdoc$/i, "") + ".pdf";
     }
 
-    // Write HTML to temp file for Chrome to consume
-    const tmpHtml = path.join(os.tmpdir(), "sdoc-slides-" + Date.now() + ".html");
+    // Write HTML to a temp file for Chrome to consume.
+    //
+    // The tmp file must sit in the same directory as the input .sdoc so
+    // that relative asset references in the HTML (e.g. <img src="./diagrams/foo.svg">)
+    // resolve correctly when Chrome prints the page.  Writing to os.tmpdir()
+    // breaks the diagrams in the resulting PDF.
+    const tmpHtml = path.join(path.dirname(resolvedInput), ".sdoc-slides-pdf-" + Date.now() + ".html");
     fs.writeFileSync(tmpHtml, html, "utf-8");
 
     try {


### PR DESCRIPTION
## Summary
Releases **v0.2.15** to main.

- **Vertical drilldown (detail) slides** — `:detail` children become sibling slides with `N.K` indicator notation, flattened for PDF.
- **Scale slide content to fit page in PDF export.**
- **Inline local images as data URIs** in HTML/PDF exports so output is self-contained — fixes relative image paths (e.g. `diagrams/foo.svg`) that broke when rendering from a temp directory.
- Ensure PDF output directory exists before writing.

## Test plan
- Full suite passes: `node test/test-all.js && node test/test-knr.js && node test/test-slides.js` → 534 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)