### PR TITLE
v0.2.16: Hex color codes render as inline swatches

### DIFF
--- a/docs/reference/api.sdoc
+++ b/docs/reference/api.sdoc
@@ -281,7 +281,7 @@ slugify("Table Formulas"); // "table-formulas"
             - `hr` -- a horizontal rule
         }
 
-        Inline image nodes (`type: "image"`) within paragraphs include `src`, `alt`, and optional `width` (e.g. `"50%"`) and `align` (`"center"`, `"left"`, or `"right"`). Inline citation reference nodes (`type: "citation_ref"`) include `keys` (array of citation key strings).
+        Inline image nodes (`type: "image"`) within paragraphs include `src`, `alt`, and optional `width` (e.g. `"50%"`) and `align` (`"center"`, `"left"`, or `"right"`). Inline citation reference nodes (`type: "citation_ref"`) include `keys` (array of citation key strings). Inline hex color nodes (`type: "color_swatch"`) include `value` (the matched hex string, e.g. `"#9aa0a8"`) and render as a self-contained swatch.
     }
 
     # exportSlidePdf(htmlPath, pdfPath)

--- a/docs/reference/sdoc-authoring.sdoc
+++ b/docs/reference/sdoc-authoring.sdoc
@@ -384,7 +384,10 @@ Content of Section B.
                 \`\{!text!\}\` | Warning marker (orange)
                 \`\{-text-\}\` | Negative marker (red)
                 \`\{~text~\}\` | Highlight (yellow)
+                \`#1a73e8\` | Hex color swatch (auto-readable text)
             }
+
+            Hex color codes (\`#rgb\`, \`#rgba\`, \`#rrggbb\`, \`#rrggbbaa\`) render as inline swatches — a rounded box filled with the color and labelled with the code, with the text color chosen automatically (black or white) for legibility. They are detected in normal text, list items, table cells, and headings, but not inside \`\\\`inline code\\\`\` (which stays literal). A bare \`#\` at the start of a line is a heading; escape with \`\\#\` to keep a literal hash.
 
             Links: \`[Link text](https://example.com)\` or \`[Other doc](./other-file.sdoc)\`. Relative paths resolve from the document's directory.
 

--- a/docs/reference/syntax.sdoc
+++ b/docs/reference/syntax.sdoc
@@ -310,9 +310,12 @@ Content of Section B.
             - `{!text!}` renders as {!warning (orange) marker!}
             - `{-text-}` renders as {-negative (red) marker-}
             - `{~text~}` renders as {~highlighted text~}
+            - `#9aa0a8` renders as a color swatch #9aa0a8 (text color auto-chosen for contrast)
         }
 
         A plain `$` followed by a digit (e.g. `$100`) does not trigger math. Use `\$` to escape dollar signs adjacent to math.
+
+        Hex color codes (`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`) render as inline swatches: #1a73e8 #fbbc04 #202124 #fff. They are recognized in text, list items, table cells, and headings, but not inside `` `inline code` ``. A `#` at the very start of a line is a heading — escape with `\#` for a literal hash.
     }
 
     # Links and Images

--- a/examples/example.sdoc
+++ b/examples/example.sdoc
@@ -25,6 +25,7 @@
 
         You can use *emphasis*, **strong**, and `inline code`.
         Semantic markers: {+positive+}, {=neutral=}, {^note^}, {?caution?}, {!warning!}, {-negative-}. Highlight: {~important note~}. Nesting works: {+**all checks** passed+}.
+        Hex color codes render as swatches: primary #1a73e8, surface #9aa0a8, accent #fbbc04, ink #202124, paper #fff. Short and alpha forms work too: #f00, #00ff0080.
         External links look like [SDOC](https://example.com).
     }
     # Examples

--- a/lexica/specification.sdoc
+++ b/lexica/specification.sdoc
@@ -719,11 +719,14 @@ Content of Section B.
                 - Warning marker: `{!text!}` (orange highlight)
                 - Negative marker: `{-text-}` (red highlight)
                 - Highlight: `{~text~}` (yellow highlight)
+                - Hex color swatch: `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa` (e.g. `#9aa0a8`) renders as a filled inline box labelled with the code
                 - Citation reference: `[@key]` (numbered superscript link to citation entry)
                 - Multiple citation references: `[@key1, @key2]` (each individually linked)
             }
 
             Inline math requires non-whitespace immediately after the opening `$` and before the closing `$`. A plain `$` followed by a digit (e.g. `$100`) does not trigger math mode because there is no closing `$`.
+
+            Hex color swatches are detected only when the `#` is at the start of the inline text or preceded by a non-alphanumeric character, the digit run is exactly 3, 4, 6, or 8 hexadecimal digits, and it is not immediately followed by another letter, digit, or underscore. The background is the literal color and the text color (black or white) is chosen by perceptual brightness (YIQ); for `#rgba`/`#rrggbbaa` the alpha channel is ignored when choosing the text color. Hex inside `` `inline code` `` stays literal, and a `#` at the start of a line is parsed as a heading (escape with `\#`).
 
             Citation references (`[@key]`) are parsed before link syntax. `[@key]` is always a citation reference even if followed by `(url)`. Use `\[@key]` for a literal `[@key]` in text.
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sdoc",
   "displayName": "SDOC - Docs for Human/Agent Teams",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "publisher": "entropicwarrior-msenfin",
   "license": "MIT",
   "repository": {

--- a/src/sdoc.js
+++ b/src/sdoc.js
@@ -1414,6 +1414,21 @@ function parseInline(text) {
       }
     }
 
+    // Hex color codes (#rgb, #rgba, #rrggbb, #rrggbbaa) render as swatches.
+    // Require a non-word char before the # so we don't match inside identifiers,
+    // and a non-word char after the digits so partial/over-long runs are ignored.
+    if (ch === "#" && (i === 0 || !/[0-9A-Za-z]/.test(text[i - 1]))) {
+      const m = /^#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9A-Za-z_])/.exec(
+        text.slice(i)
+      );
+      if (m) {
+        flush();
+        nodes.push({ type: "color_swatch", value: m[0] });
+        i += m[0].length;
+        continue;
+      }
+    }
+
     if (ch === "{") {
       const mc = next;
       let mt = null;
@@ -1728,6 +1743,46 @@ function escapeAttr(value) {
   return escapeHtml(value).replace(/'/g, "&#39;");
 }
 
+// Expand a #rgb/#rgba/#rrggbb/#rrggbbaa hex string to [r, g, b] (alpha ignored).
+function hexToRgb(hex) {
+  let h = hex.replace(/^#/, "");
+  if (h.length === 3 || h.length === 4) {
+    h = h.slice(0, 3).split("").map((c) => c + c).join("");
+  } else {
+    h = h.slice(0, 6);
+  }
+  return [
+    parseInt(h.slice(0, 2), 16),
+    parseInt(h.slice(2, 4), 16),
+    parseInt(h.slice(4, 6), 16),
+  ];
+}
+
+// Pick black or white text for legibility over the given background color
+// using the perceptual YIQ brightness threshold.
+function readableTextColor(hex) {
+  const [r, g, b] = hexToRgb(hex);
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+  return yiq >= 128 ? "#000000" : "#ffffff";
+}
+
+// Render a hex color as a self-contained inline swatch: a rounded box filled
+// with the color, labelled with the hex code in a legible text color. Styling
+// is inline so it survives in slides, exports, and other CSS-free contexts.
+function colorSwatchHtml(value) {
+  const fg = readableTextColor(value);
+  // A soft neutral-grey outline on every swatch (the same for all of them) so
+  // the box edge stays visible even when the fill matches the page background.
+  // Semi-transparent grey reads on both light and dark backgrounds without the
+  // harsh contrast of a black/white border.
+  const style =
+    `background-color:${value};color:${fg};` +
+    "border:1px solid rgba(128,128,128,0.5);border-radius:4px;padding:0.15em 0.9em;" +
+    "font-family:'JetBrains Mono','Fira Code','Source Code Pro',monospace;font-size:0.95em;" +
+    "-webkit-print-color-adjust:exact;print-color-adjust:exact";
+  return `<span class="sdoc-color-swatch" style="${style}">${escapeHtml(value)}</span>`;
+}
+
 function renderInline(text) {
   const nodes = parseInline(text);
   return renderInlineNodes(nodes);
@@ -1766,6 +1821,8 @@ function renderInlineNodes(nodes) {
         }
         case "code":
           return `<code class="sdoc-inline-code">${escapeHtml(node.value)}</code>`;
+        case "color_swatch":
+          return colorSwatchHtml(node.value);
         case "em":
           return `<em>${renderInlineNodes(node.children)}</em>`;
         case "strong":
@@ -3773,5 +3830,7 @@ module.exports = {
   renderKatex,
   escapeHtml,
   escapeAttr,
-  sanitizeSvg
+  sanitizeSvg,
+  colorSwatchHtml,
+  readableTextColor
 };

--- a/src/slide-renderer.js
+++ b/src/slide-renderer.js
@@ -7,7 +7,7 @@
 //   const { nodes, meta } = extractMeta(parsed.nodes);
 //   const html = renderSlides(nodes, { meta, themeCss, themeJs });
 
-const { parseInline, renderKatex, escapeHtml, escapeAttr, sanitizeSvg } = require("./sdoc");
+const { parseInline, renderKatex, escapeHtml, escapeAttr, sanitizeSvg, colorSwatchHtml } = require("./sdoc");
 
 // ---------------------------------------------------------------------------
 // Inline rendering — produces clean HTML without sdoc-* classes
@@ -21,6 +21,8 @@ function renderInlineNodes(nodes) {
           return escapeHtml(node.value);
         case "code":
           return `<code>${escapeHtml(node.value)}</code>`;
+        case "color_swatch":
+          return colorSwatchHtml(node.value);
         case "em":
           return `<em>${renderInlineNodes(node.children)}</em>`;
         case "strong":

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -23,7 +23,8 @@ const {
   collectCitationDefinitions,
   validateRefs,
   validateCitations,
-  sanitizeSvg
+  sanitizeSvg,
+  readableTextColor
 } = require("../src/sdoc.js");
 const fs = require("fs");
 const path = require("path");
@@ -3462,6 +3463,106 @@ test("formatter handles K&R citations", () => {
   const input = "# Refs {[citations]\n- @smith Smith, 2020.\n}";
   const formatted = formatSdoc(input);
   assert(formatted.includes("    - @smith"), "citation item indented under K&R");
+});
+
+console.log("\n--- Hex Color Swatches ---");
+
+test("6-digit hex renders as swatch with background color", () => {
+  const html = renderHtmlBody("The color is #9aa0a8 here.");
+  assert(html.includes('class="sdoc-color-swatch"'), "has swatch class");
+  assert(html.includes("background-color:#9aa0a8"), "has background color");
+  assert(html.includes(">#9aa0a8</span>"), "labels with hex code");
+});
+
+test("3-digit hex renders as swatch", () => {
+  const html = renderHtmlBody("Use #fff for white.");
+  assert(html.includes("background-color:#fff"), "has 3-digit background");
+  assert(html.includes(">#fff</span>"), "labels with 3-digit hex");
+});
+
+test("4-digit (rgba) and 8-digit (rrggbbaa) hex render as swatches", () => {
+  const html4 = renderHtmlBody("alpha #f00a done");
+  assert(html4.includes("background-color:#f00a"), "4-digit swatch");
+  const html8 = renderHtmlBody("alpha #9aa0a880 done");
+  assert(html8.includes("background-color:#9aa0a880"), "8-digit swatch");
+});
+
+test("dark background gets white text, light gets black", () => {
+  const dark = renderHtmlBody("bg #000000 here");
+  assert(dark.includes("color:#ffffff"), "black bg -> white text");
+  const light = renderHtmlBody("bg #ffffff here");
+  assert(light.includes("color:#000000"), "white bg -> black text");
+});
+
+test("readableTextColor picks legible foreground", () => {
+  assert(readableTextColor("#000000") === "#ffffff", "black -> white");
+  assert(readableTextColor("#ffffff") === "#000000", "white -> black");
+  assert(readableTextColor("#9aa0a8") === "#000000", "mid-light grey -> black");
+  assert(readableTextColor("#1a1a2e") === "#ffffff", "dark navy -> white");
+  // alpha is ignored when choosing contrast
+  assert(readableTextColor("#000000ff") === "#ffffff", "8-digit ignores alpha");
+  assert(readableTextColor("#000f") === "#ffffff", "4-digit ignores alpha");
+});
+
+test("invalid hex lengths are left as plain text", () => {
+  const html5 = renderHtmlBody("not a color #12345 ok");
+  assert(!html5.includes("sdoc-color-swatch"), "5 digits -> no swatch");
+  assert(html5.includes("#12345"), "5-digit text preserved");
+  const html7 = renderHtmlBody("not a color #1234567 ok");
+  assert(!html7.includes("sdoc-color-swatch"), "7 digits -> no swatch");
+});
+
+test("hex inside a word is not a swatch", () => {
+  const html = renderHtmlBody("issue123#fff reference");
+  assert(!html.includes("sdoc-color-swatch"), "no swatch when preceded by word char");
+});
+
+test("hex followed by letters is not a swatch", () => {
+  const html = renderHtmlBody("the tag #fffghi is not a color");
+  assert(!html.includes("sdoc-color-swatch"), "trailing letters block the match");
+});
+
+test("escaped \\# is not a swatch", () => {
+  const html = renderHtmlBody("literal \\#fff stays");
+  assert(!html.includes("sdoc-color-swatch"), "escaped hash -> no swatch");
+  assert(html.includes("#fff"), "literal hash text preserved");
+});
+
+test("hex inside inline code stays literal", () => {
+  const html = renderHtmlBody("the value `#9aa0a8` literal");
+  assert(html.includes("<code"), "renders as code");
+  assert(!html.includes("sdoc-color-swatch"), "code span not turned into swatch");
+});
+
+test("swatch detected at start of inline context (list item)", () => {
+  const html = renderHtmlBody("- #9aa0a8\n- #ffffff");
+  const count = (html.match(/sdoc-color-swatch/g) || []).length;
+  assert(count === 2, "both list items become swatches, got " + count);
+});
+
+test("bare #hex at line start is a heading, not a swatch (SDOC rule)", () => {
+  const html = renderHtmlBody("#9aa0a8 leads the line");
+  assert(!html.includes("sdoc-color-swatch"), "line-start hash is a heading");
+  assert(/<h1[^>]*>/.test(html), "renders as a heading");
+});
+
+test("swatch print color is preserved", () => {
+  const html = renderHtmlBody("swatch #9aa0a8 here");
+  assert(html.includes("print-color-adjust:exact"), "print color retained");
+});
+
+test("all swatches share the same soft neutral outline (consistent, visible on any bg)", () => {
+  const border = "border:1px solid rgba(128,128,128,0.5)";
+  ["bg #ffffff x", "bg #000000 x", "bg #9aa0a8 x", "bg #1a73e8 x"].forEach((src) => {
+    assert(renderHtmlBody(src).includes(border), "neutral outline present for: " + src);
+  });
+});
+
+test("swatch style attribute is well-formed (no double quotes inside)", () => {
+  const html = renderHtmlBody("swatch #9aa0a8 here");
+  const m = html.match(/<span class="sdoc-color-swatch" style="([^"]*)"/);
+  assert(m, "style attribute parses without an embedded double quote");
+  assert(m[1].includes("font-family:'JetBrains Mono'"), "font names use single quotes");
 });
 
 // ============================================================


### PR DESCRIPTION
## Summary
Hex color codes render as inline swatches.

- `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa` in text, list items, table cells, and headings render as a filled rounded box labelled with the code.
- Text color (black/white) chosen automatically via YIQ brightness for legibility.
- Soft neutral outline (`rgba(128,128,128,0.5)`) on every swatch so the box stays visible when its fill matches the page background — consistent on light and dark themes.
- Codes inside `` `inline code` `` stay literal; a leading `#` is still a heading (escape with `\#`).
- Shared `colorSwatchHtml`/`readableTextColor` helpers reused by both the document and slide renderers; styling is fully inline so swatches survive in slides, exports, and CSS-free contexts.

## Docs
Updated authoring reference, syntax reference, specification, and API node types; added an example to `examples/example.sdoc`.

## Test plan
- 549 tests pass: `node test/test-all.js && node test/test-knr.js && node test/test-slides.js` (14 new covering all hex lengths, contrast choice, word-boundary rejection, escaping, inline-code literalness, line-start heading rule, outline consistency, and attribute well-formedness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)