### PR TITLE
Scale slides to fill the window (v0.2.18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sdoc",
   "displayName": "SDOC - Docs for Human/Agent Teams",
   "description": "A plain-text documentation format with explicit brace scoping — deterministic parsing, AI-agent efficiency, and 10-50x token savings vs Markdown.",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "publisher": "entropicwarrior-msenfin",
   "license": "MIT",
   "repository": {

--- a/src/slide-renderer.js
+++ b/src/slide-renderer.js
@@ -394,7 +394,37 @@ function renderSlides(nodes, options = {}) {
 
   // Structural styles — always injected regardless of theme.
   const structuralCss = `
-.slide { position: relative; }
+/* --- Fixed design box + fit-to-window scaling ---------------------------
+   Slides are laid out at a fixed design size (1280x720 CSS px, which is
+   exactly the 13.333in x 7.5in print page at 96dpi) and then scaled as a
+   whole to fill the window.  This is the standard deck technique: the
+   author's layout is preserved verbatim at every window size, and screen
+   and PDF are the same geometry by construction.
+
+   --sdoc-slide-scale is written by the theme runtime (fitSlidesToWindow in
+   themes/default/theme.js) on load and on resize.  If JS never runs the
+   scale stays 1 and the deck renders at its natural design size, which is
+   the pre-scaling behaviour rather than a broken one.
+
+   Themes must NOT set width/height/max-width/margin on .slide — those come
+   from the design-box variables below.  A theme that wants a different
+   aspect ratio should override --sdoc-slide-w / --sdoc-slide-h on :root
+   (and the @page size in the print block, if PDF output matters). */
+:root {
+  --sdoc-slide-w: 1280px;
+  --sdoc-slide-h: 720px;
+  --sdoc-slide-scale: 1;
+}
+.slide {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: var(--sdoc-slide-w);
+  height: var(--sdoc-slide-h);
+  transform: translate(-50%, -50%) scale(var(--sdoc-slide-scale));
+  transform-origin: center center;
+  overflow: hidden;
+}
 .slide-footer {
   position: absolute; bottom: 20px; left: 32px; right: 32px;
   display: flex; align-items: baseline;
@@ -440,7 +470,14 @@ function renderSlides(nodes, options = {}) {
     opacity: 1 !important;
     pointer-events: auto !important;
     page-break-after: always; break-after: page;
-    width: 100vw; height: 100vh; max-width: none;
+    /* The design box IS the page (1280x720px == 13.333in x 7.5in @96dpi),
+       so no fit-to-window scaling applies here — each slide flows as one
+       page at its natural size.  Overflowing content is still shrunk by
+       the inner .slide-content-scale wrapper (see fitSlidesForPrint). */
+    top: auto !important; left: auto !important;
+    transform: none !important;
+    margin: 0 !important;
+    width: var(--sdoc-slide-w); height: var(--sdoc-slide-h); max-width: none;
     overflow: hidden;
     page-break-inside: avoid; break-inside: avoid;
   }

--- a/test/test-slides.js
+++ b/test/test-slides.js
@@ -452,6 +452,54 @@ test("rendered slides include print styles", () => {
   assert(html.includes("display: block !important"), "should force slides visible in print");
 });
 
+// ============================================================
+console.log("\n--- Fit-to-window scaling ---");
+
+test("structural CSS defines the fixed design box", () => {
+  const html = parseAndRender(`
+# Deck {
+    # Slide { Hello. }
+}
+`);
+  assert(html.includes("--sdoc-slide-w: 1280px"), "design box width defined");
+  assert(html.includes("--sdoc-slide-h: 720px"), "design box height defined");
+  // Must default to 1 so a deck with no JS renders at natural size rather
+  // than collapsing to scale(0).
+  assert(html.includes("--sdoc-slide-scale: 1"), "scale defaults to 1");
+});
+
+test("slides are sized from the design box and scaled by the variable", () => {
+  const html = parseAndRender(`
+# Deck {
+    # Slide { Hello. }
+}
+`);
+  assert(html.includes("width: var(--sdoc-slide-w)"), "slide width from design box");
+  assert(html.includes("height: var(--sdoc-slide-h)"), "slide height from design box");
+  assert(
+    html.includes("scale(var(--sdoc-slide-scale))"),
+    "slide transform reads the scale variable"
+  );
+});
+
+test("print neutralizes the screen transform so each slide is one page", () => {
+  const html = parseAndRender(`
+# Deck {
+    # Slide { Hello. }
+}
+`);
+  const printBlock = html.slice(html.indexOf("@media print"));
+  assert(printBlock.includes("transform: none !important"), "screen scale is cleared in print");
+  assert(
+    printBlock.includes("position: relative !important"),
+    "slides return to flow so they paginate"
+  );
+  assert(
+    printBlock.includes("width: var(--sdoc-slide-w)"),
+    "print page uses the same design box as screen"
+  );
+});
+
 test("findChrome returns a string or null", () => {
   const { findChrome } = require("../src/slide-pdf");
   const result = findChrome();

--- a/themes/default/theme.css
+++ b/themes/default/theme.css
@@ -12,14 +12,15 @@ body {
 
 /* --- Slide layout --- */
 
+/* Size, position and fit-to-window scaling of .slide come from the
+   renderer's structural CSS (the --sdoc-slide-w/h design box). Setting
+   height/max-width/margin here would override it and pin the deck back to
+   a fixed-width column, so this rule styles only the inside of the box. */
 .slide {
   display: none;
   flex-direction: column;
   justify-content: center;
   padding: 60px 100px;
-  height: 100vh;
-  max-width: 1200px;
-  margin: 0 auto;
 }
 
 .slide.active { display: flex; }

--- a/themes/default/theme.js
+++ b/themes/default/theme.js
@@ -189,7 +189,22 @@
   // ---------------------------------------------------------------------
   var docEl = document.documentElement;
 
+  // Resolve the design box in CSS pixels.
+  //
+  // Measure the laid-out slide rather than parsing --sdoc-slide-w/h.  Custom
+  // properties are not resolved to px by getComputedStyle — the raw token
+  // comes back verbatim — so a theme overriding the box in any non-px unit
+  // ("13.333in", "80rem") would parse to a meaningless number.  offsetWidth /
+  // offsetHeight report the *layout* border box in px and ignore transforms,
+  // so they give the true design size whatever unit declared it, and are not
+  // perturbed by the scale this function itself applies.
   function designBox() {
+    var el = document.querySelector(".slide.active") || document.querySelector(".slide");
+    if (el && el.offsetWidth > 0 && el.offsetHeight > 0) {
+      return { w: el.offsetWidth, h: el.offsetHeight };
+    }
+    // No laid-out slide to measure (e.g. all hidden): fall back to the
+    // declared values, which are px in the shipped structural CSS.
     var cs = getComputedStyle(docEl);
     var w = parseFloat(cs.getPropertyValue("--sdoc-slide-w"));
     var h = parseFloat(cs.getPropertyValue("--sdoc-slide-h"));

--- a/themes/default/theme.js
+++ b/themes/default/theme.js
@@ -176,6 +176,64 @@
   });
 
   // ---------------------------------------------------------------------
+  // Screen rendering: scale the fixed design box to fill the window.
+  //
+  // Slides are laid out at a fixed design size (--sdoc-slide-w x
+  // --sdoc-slide-h, default 1280x720) and the whole slide is scaled by a
+  // single factor so it fills as much of the window as it can while
+  // keeping its aspect ratio.  Unlike fitSlidesForPrint below, this is NOT
+  // clamped at 1 — on a window larger than the design box the deck scales
+  // up, which is the entire point: a 1920x1080 window gets 1.5x, 2560x1440
+  // gets 2x.  The scale is published as a CSS variable on :root so one
+  // write restyles every slide.
+  // ---------------------------------------------------------------------
+  var docEl = document.documentElement;
+
+  function designBox() {
+    var cs = getComputedStyle(docEl);
+    var w = parseFloat(cs.getPropertyValue("--sdoc-slide-w"));
+    var h = parseFloat(cs.getPropertyValue("--sdoc-slide-h"));
+    return {
+      w: w > 0 ? w : 1280,
+      h: h > 0 ? h : 720
+    };
+  }
+
+  function fitSlidesToWindow() {
+    // Print has its own geometry (the design box is the page, unscaled);
+    // the print stylesheet forces transform:none, so skip the work.
+    if (window.matchMedia && window.matchMedia("print").matches) return;
+    var box = designBox();
+    var vw = window.innerWidth;
+    var vh = window.innerHeight;
+    if (!vw || !vh) return;
+    var k = Math.min(vw / box.w, vh / box.h);
+    if (!isFinite(k) || k <= 0) return;
+    docEl.style.setProperty("--sdoc-slide-scale", String(k));
+  }
+
+  // Coalesce resize bursts into one recompute per frame.
+  var fitQueued = false;
+  function queueFit() {
+    if (fitQueued) return;
+    fitQueued = true;
+    var run = function () {
+      fitQueued = false;
+      fitSlidesToWindow();
+    };
+    if (typeof requestAnimationFrame === "function") requestAnimationFrame(run);
+    else setTimeout(run, 16);
+  }
+
+  fitSlidesToWindow();
+  window.addEventListener("resize", queueFit);
+  window.addEventListener("orientationchange", queueFit);
+  // Web fonts can change metrics after first paint; re-fit once they land.
+  if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === "function") {
+    document.fonts.ready.then(fitSlidesToWindow);
+  }
+
+  // ---------------------------------------------------------------------
   // PDF / print rendering: measure each slide's natural content size and
   // apply transform: scale() so the content fits the page exactly.  In
   // screen mode .slide-content-scale is display:contents (invisible to


### PR DESCRIPTION
## Problem

Slides were laid out at a fixed 16px root font size inside a `max-width: 1200px` column. The type stayed the same physical size regardless of window size, so a deck used ~62% of the width at 1920×1080 and ~47% at 2560×1440.

## Approach

Lay every slide out at a fixed **1280×720** design box — exactly the `@page` 13.333in × 7.5in at 96dpi — and scale the whole slide to fit the window. Screen and PDF now share one geometry by construction.

Scale factors vs. the flat 1.0× before: **1.5× at 1920×1080, 2.0× at 2560×1440, 3.0× at 4K.**

The `.slide-content-scale` wrapper added for PDF export already measured and scaled content, but it could only ever shrink (clamped at 1) and was inert on screen (`display: contents`). That wrapper keeps its original print-overflow job unchanged — the new fit is a separate, **outer** scale on `.slide`, driven by `--sdoc-slide-scale`.

Deliberately leaving the wrapper at `display: contents` on screen means no extra layout node appears between `.slide` and its content, so existing themes and per-slide overrides render unchanged.

## Changes

- `src/slide-renderer.js` — `--sdoc-slide-w/h/scale` variables; `.slide` becomes a centred fixed box with `scale(var(--sdoc-slide-scale))`; print block neutralises the transform so slides still paginate.
- `themes/default/theme.js` — `fitSlidesToWindow()`, no clamp at 1, rAF-debounced on resize/orientationchange, re-fits after web fonts load.
- `themes/default/theme.css` — drops `height/max-width/margin` from `.slide`.
- `test/test-slides.js` — 3 regression tests (design box defined, slide reads the scale var, print neutralises the transform).
- `package.json` — 0.2.17 → 0.2.18.

## Breaking change for themes

Themes must no longer set `width`/`height`/`max-width`/`margin` on `.slide` — the design box owns those. A theme setting `max-width` will pin the deck back to a fixed column. Decks wanting a different aspect ratio override `--sdoc-slide-w/h` on `:root` (and the `@page` size, for PDF).

## Verification

- 484 tests pass (`test-all.js`), 54 slide tests including the 3 new ones.
- `npx vsce package` produces `vscode-sdoc-0.2.18.vsix` cleanly — same command the release workflow runs.
- Rendered the Irréversible IDEaS deck (29 slides) at 1024×640, 1440×900, 1920×1080, 2560×800, 2560×1440: fills the frame, letterboxes correctly at extreme aspect ratios, nothing clipped.
- Layout overrides verified intact: three-column grid, `nth-of-type` stacks, a 2×2 image grid, full-width SVG figures.
- PDF export: 29 pages, MediaBox 960×540pt = exactly 13.333in × 7.5in.

## Note

`v0.2.17` is 2 commits behind `main`, so releasing 0.2.18 also ships the two unreleased commits already on `main` (`05e9c2f` exclude @meta/@about scopes, `1c83ab1` footer stacking fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)